### PR TITLE
Make format and fixes, see details...

### DIFF
--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -36,8 +36,9 @@ public:
     std::list<Subscriptions::Remote> list = subscribeList.find(quicr_name);
 
     for (auto dest: list) {
+			quicr::bytes copy = data;
       server->sendNamedObject(dest.subscribe_id,
-                              quicr_name, 0, 0, false, std::move(data));
+                              quicr_name, 0, 0, false, std::move(copy));
     }
 
 

--- a/cmd/really/subscription.h
+++ b/cmd/really/subscription.h
@@ -13,8 +13,8 @@ public:
 
   struct Remote {
     uint64_t subscribe_id;
-    u_int64_t context_id;
-    u_int64_t stream_id;
+    uint64_t context_id;
+    uint64_t stream_id;
 
     bool operator==(const Remote &o) const {
       return subscribe_id == o.subscribe_id

--- a/include/quicr/hex_endec.h
+++ b/include/quicr/hex_endec.h
@@ -8,6 +8,9 @@
 #include <limits>
 #include <sstream>
 #include <vector>
+#include <cassert>
+#include <algorithm>
+#include <bitset>
 
 namespace quicr {
 /**

--- a/include/quicr/quicr_server.h
+++ b/include/quicr/quicr_server.h
@@ -6,9 +6,9 @@
 #include <thread>
 #include <vector>
 
-#include <quicr/message_buffer.h>
-#include <quicr/quicr_common.h>
-#include <transport/transport.h>
+#include "message_buffer.h"
+#include "quicr_common.h"
+#include "transport/transport.h"
 
 /*
  * API for implementing server side of the QUICR protocol
@@ -145,6 +145,22 @@ public:
                            bytes&& data)
   {
   }
+
+  /**
+   * @brief Unsubscribe callback method
+   *
+   * @details Called for each unsubscribe message
+   *
+   * @param quicr_namespace          QuicR name/len
+   * @param subscriber_id            Subscriber ID connection/transport that
+   *                                 sent the message
+   * @param auth_token               Auth token to verify if value
+   */
+  virtual void onUnsubscribe(const quicr::Namespace& quicr_namespace,
+                             const uint64_t& subscriber_id,
+                             const std::string& auth_token)
+  {
+  }
 };
 
 class QuicRServer
@@ -165,7 +181,8 @@ public:
    * API for unit test cases .
    */
   QuicRServer(std::shared_ptr<qtransport::ITransport> transport,
-              ServerDelegate& delegate, qtransport::LogHandler& logger);
+              ServerDelegate& delegate /* TODO: Considering shared or weak pointer */,
+              qtransport::LogHandler& logger);
 
   // Transport APIs
   bool is_transport_ready();

--- a/include/quicr/quicr_server.h
+++ b/include/quicr/quicr_server.h
@@ -6,9 +6,9 @@
 #include <thread>
 #include <vector>
 
-#include "message_buffer.h"
-#include "quicr_common.h"
-#include "transport/transport.h"
+#include <quicr/message_buffer.h>
+#include <quicr/quicr_common.h>
+#include <transport/transport.h>
 
 /*
  * API for implementing server side of the QUICR protocol

--- a/src/quicr_server.cpp
+++ b/src/quicr_server.cpp
@@ -3,8 +3,9 @@
 
 #include "encode.h"
 #include "quicr/message_buffer.h"
-#include <thread>
 #include <iostream>
+#include <sstream>
+#include <thread>
 
 namespace quicr {
 
@@ -209,18 +210,33 @@ QuicRServer::TransportDelegate::on_connection_status(
   const qtransport::TransportContextId& context_id,
   const qtransport::TransportStatus status)
 {
+  std::stringstream log_msg;
+  log_msg << "connection_status: cid: " << context_id << " status: " << int(status);
+  server.log_handler.log(qtransport::LogLevel::debug, log_msg.str());
 }
+
 void
 QuicRServer::TransportDelegate::on_new_connection(
   const qtransport::TransportContextId& context_id,
   const qtransport::TransportRemote& remote)
 {
+  std::stringstream log_msg;
+  log_msg << "new_connection: cid: " << context_id
+          << " remote: " << remote.host_or_ip
+          << " port:" << ntohs(remote.port);
+  server.log_handler.log(qtransport::LogLevel::debug, log_msg.str());
 }
+
 void
 QuicRServer::TransportDelegate::on_new_media_stream(
   const qtransport::TransportContextId& context_id,
   const qtransport::MediaStreamId& mStreamId)
 {
+  std::stringstream log_msg;
+  log_msg << "new_stream: cid: " << context_id
+          << " msid: " << mStreamId;
+
+  server.log_handler.log(qtransport::LogLevel::debug, log_msg.str());
 }
 
 void

--- a/src/quicr_server.cpp
+++ b/src/quicr_server.cpp
@@ -7,6 +7,8 @@
 #include <sstream>
 #include <thread>
 
+#include <arpa/inet.h>
+
 namespace quicr {
 
 /*


### PR DESCRIPTION
* ```make format```
* Updated transport submodule to use latest with other fixes
* Fixed really where subscribers would get empty data. This was caused by ```std::move()```.
* Fixed missing header files that blocked linux/docker builds
* Add ```onUnsubscribe``` callback to server delegate. Implementation still pending.
* Added debug logging to callbacks that are not yet implemented