### PR TITLE
Reducing warnings.

### DIFF
--- a/cmd/really/CMakeLists.txt
+++ b/cmd/really/CMakeLists.txt
@@ -9,6 +9,6 @@ target_compile_options(really
         $<$<CXX_COMPILER_ID:MSVC>: >)
 set_target_properties(really
     PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS ON)

--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -11,7 +11,7 @@ public:
 
   ~ReallyServer() = default;
   ReallyServer() {
-    quicr::RelayInfo relayInfo = { hostname: "127.0.0.1", port: 1234, proto: quicr::RelayInfo::Protocol::UDP };
+    quicr::RelayInfo relayInfo = { .hostname = "127.0.0.1", .port = 1234, .proto = quicr::RelayInfo::Protocol::UDP };
 
     qtransport::LogHandler logger;
     server = std::make_unique<quicr::QuicRServer>(relayInfo,
@@ -19,16 +19,16 @@ public:
                                                   logger);
   }
 
-  virtual void onPublishIntent(const quicr::Namespace& quicr_name,
-                               const std::string& origin_url,
-                               bool use_reliable_transport,
-                               const std::string& auth_token,
-                               quicr::bytes&& e2e_token) {};
+  virtual void onPublishIntent(const quicr::Namespace& /*quicr_name */,
+                               const std::string& /* origin_url */,
+                               bool /* use_reliable_transport */,
+                               const std::string& /* auth_token */,
+                               quicr::bytes&& /* e2e_token */) {};
 
   virtual void onPublisherObject(const quicr::Name& quicr_name,
-                                 uint8_t priority,
-                                 uint16_t expiry_age_ms,
-                                 bool use_reliable_transport,
+                                 [[maybe_unused]] uint8_t priority,
+                                 [[maybe_unused]] uint16_t expiry_age_ms,
+                                 [[maybe_unused]] bool use_reliable_transport,
                                  quicr::bytes&& data)  {
 
     std::cout << " onPublisherObject: Name " << quicr_name.to_hex() << std::endl;
@@ -44,27 +44,27 @@ public:
 
   }
 
-  virtual void onPublishedFragment(const quicr::Name& quicr_name,
-                                   uint8_t priority,
-                                   uint16_t expiry_age_ms,
-                                   bool use_reliable_transport,
-                                   const uint64_t& offset,
-                                   bool is_last_fragment,
-                                   quicr::bytes&& data)
+  virtual void onPublishedFragment(const quicr::Name& /* quicr_name */,
+                                   uint8_t /* priority */,
+                                   uint16_t /* expiry_age_ms */,
+                                   bool /* use_reliable_transport */,
+                                   const uint64_t& /* offset */,
+                                   bool /* is_last_fragment */,
+                                   quicr::bytes&& /* data */)
   {
   }
 
   virtual void onSubscribe(const quicr::Namespace& quicr_namespace,
                            const uint64_t& subscriber_id,
-                           const quicr::SubscribeIntent subscribe_intent,
-                           const std::string& origin_url,
-                           bool use_reliable_transport,
-                           const std::string& auth_token,
-                           quicr::bytes&& data)
+                           [[maybe_unused]] const quicr::SubscribeIntent subscribe_intent,
+                           [[maybe_unused]] const std::string& origin_url,
+                           [[maybe_unused]] bool use_reliable_transport,
+                           [[maybe_unused]] const std::string& auth_token,
+                           [[maybe_unused]] quicr::bytes&& data)
   {
     std::cout << " onSubscribe: Namespace " << quicr_namespace.to_hex() << std::endl;
 
-    Subscriptions::Remote remote = { subscribe_id: subscriber_id };
+    Subscriptions::Remote remote = { .subscribe_id = subscriber_id };
     subscribeList.add(quicr_namespace.name(), quicr_namespace.length(), remote);
 
 
@@ -73,17 +73,17 @@ public:
     server->subscribeResponse(quicr_namespace, 0x0, result);
   }
 
-  virtual void on_connection_status(const qtransport::TransportContextId &context_id,
-                                    const qtransport::TransportStatus status) {}
+  virtual void on_connection_status(const qtransport::TransportContextId& /* context_id */,
+                                    const qtransport::TransportStatus /* status */) {}
 
-  virtual void on_new_connection(const qtransport::TransportContextId &context_id,
-                                 const qtransport::TransportRemote &remote) {}
+  virtual void on_new_connection(const qtransport::TransportContextId& /* context_id */,
+                                 const qtransport::TransportRemote& /* remote */) {}
 
-  virtual void on_new_media_stream(const qtransport::TransportContextId &context_id,
-                                   const qtransport::MediaStreamId &mStreamId) {}
+  virtual void on_new_media_stream(const qtransport::TransportContextId& /* context_id */,
+                                   const qtransport::MediaStreamId& /* mStreamId */) {}
 
-  virtual void on_recv_notify(const qtransport::TransportContextId &context_id,
-                              const qtransport::MediaStreamId &mStreamId) {}
+  virtual void on_recv_notify(const qtransport::TransportContextId& /* context_id */,
+                              const qtransport::MediaStreamId& /* mStreamId */) {}
 
   std::unique_ptr<quicr::QuicRServer> server;
   std::shared_ptr<qtransport::ITransport> transport;

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -77,9 +77,7 @@ public:
                                   uint8_t priority,
                                   uint16_t expiry_age_ms,
                                   bool use_reliable_transport,
-                                  bytes&& data)
-  {
-  }
+                                  bytes&& data);
 
   /**
    * @brief Report arrival of subscribed QUICR object fragment under a Name
@@ -108,9 +106,7 @@ public:
                                           bool use_reliable_transport,
                                           const uint64_t& offset,
                                           bool is_last_fragment,
-                                          bytes&& data)
-  {
-  }
+                                          bytes&& data);
 };
 
 /**

--- a/include/quicr/quicr_server.h
+++ b/include/quicr/quicr_server.h
@@ -111,9 +111,7 @@ public:
                                    bool use_reliable_transport,
                                    const uint64_t& offset,
                                    bool is_last_fragment,
-                                   bytes&& data)
-  {
-  }
+                                   bytes&& data);
 
   /*
    * @brief Report arrival of subscribe request for a QUICR Namespace
@@ -142,9 +140,7 @@ public:
                            const std::string& origin_url,
                            bool use_reliable_transport,
                            const std::string& auth_token,
-                           bytes&& data)
-  {
-  }
+                           bytes&& data);
 
   /**
    * @brief Unsubscribe callback method
@@ -158,9 +154,7 @@ public:
    */
   virtual void onUnsubscribe(const quicr::Namespace& quicr_namespace,
                              const uint64_t& subscriber_id,
-                             const std::string& auth_token)
-  {
-  }
+                             const std::string& auth_token);
 };
 
 class QuicRServer
@@ -347,15 +341,15 @@ private:
     uint64_t offset{ 0 };
   };
 
+  ServerDelegate& delegate;
   qtransport::LogHandler & log_handler;
+  TransportDelegate transport_delegate;
   std::shared_ptr<qtransport::ITransport> transport;
   qtransport::TransportRemote t_relay;
-  ServerDelegate& delegate;
   std::map<quicr::Namespace,
            std::map<qtransport::TransportContextId, SubscribeContext>> subscribe_state{};
   std::map<uint64_t , SubscribeContext> subscribe_id_state{};
   std::map<quicr::Name, PublishContext> publish_state{};
-  TransportDelegate transport_delegate;
   bool running{ false };
   uint64_t subscriber_id{ 0 };
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_options(quicr
         $<$<CXX_COMPILER_ID:MSVC>: >)
 set_target_properties(quicr
     PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS OFF)
 if(MSVC)

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -9,6 +9,25 @@
 #include "quicr/message_buffer.h"
 
 namespace quicr {
+
+void SubscriberDelegate::onSubscribedObject(const quicr::Name& /* quicr_name */,
+                                  uint8_t /* priority */,
+                                  uint16_t /* expiry_age_ms*/,
+                                  bool /* use_reliable_transport */,
+                                  bytes&& /* data */)
+{
+}
+
+void SubscriberDelegate::onSubscribedObjectFragment(const quicr::Name& /* quicr_name */,
+                                          uint8_t /* priority */,
+                                          uint16_t /* expiry_age_ms*/,
+                                          bool /* use_reliable_transport */,
+                                          const uint64_t& /* offset */,
+                                          bool /* is_last_fragment */,
+                                          bytes&& /* data */)
+{
+}
+
 ///
 /// Transport Delegate Implementation
 ///
@@ -23,20 +42,20 @@ public:
   virtual ~QuicRTransportDelegate() = default;
 
   virtual void on_connection_status(
-    const qtransport::TransportContextId& context_id,
-    const qtransport::TransportStatus status)
+    const qtransport::TransportContextId& /* context_id */,
+    const qtransport::TransportStatus /* status */ )
   {
   }
 
   virtual void on_new_connection(
-    const qtransport::TransportContextId& context_id,
-    const qtransport::TransportRemote& remote)
+    const qtransport::TransportContextId& /* context_id */,
+    const qtransport::TransportRemote& /* remote */)
   {
   }
 
   virtual void on_new_media_stream(
-    const qtransport::TransportContextId& context_id,
-    const qtransport::MediaStreamId& mStreamId)
+    const qtransport::TransportContextId& /* context_id */,
+    const qtransport::MediaStreamId& /* mStreamId */)
   {
   }
 
@@ -60,9 +79,9 @@ QuicRClient::make_transport(RelayInfo& relay_info,
                             qtransport::LogHandler& logger)
 {
   qtransport::TransportRemote server = {
-    host_or_ip : relay_info.hostname,
-    port : relay_info.port,
-    proto : relay_info.proto == RelayInfo::Protocol::UDP
+    .host_or_ip = relay_info.hostname,
+    .port = relay_info.port,
+    .proto = relay_info.proto == RelayInfo::Protocol::UDP
       ? qtransport::TransportProtocol::UDP
       : qtransport::TransportProtocol::QUIC,
   };
@@ -88,18 +107,18 @@ QuicRClient::QuicRClient(std::shared_ptr<ITransport> transport_in)
 }
 
 bool
-QuicRClient::publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
-                           const quicr::Namespace& quicr_namespace,
-                           const std::string& origin_url,
-                           const std::string& auth_token,
-                           bytes&& payload)
+QuicRClient::publishIntent(std::shared_ptr<PublisherDelegate> /* pub_delegate */,
+                           const quicr::Namespace& /* quicr_namespace */,
+                           const std::string& /* origin_url */,
+                           const std::string& /* auth_token */,
+                           bytes&& /* payload */)
 {
   throw std::runtime_error("UnImplemented");
 }
 
 void
-QuicRClient::publishIntentEnd(const quicr::Namespace& quicr_namespace,
-                              const std::string& auth_token)
+QuicRClient::publishIntentEnd(const quicr::Namespace& /* quicr_namespace */,
+                              const std::string& /* auth_token */)
 {
   throw std::runtime_error("UnImplemented");
 }
@@ -108,10 +127,10 @@ void
 QuicRClient::subscribe(std::shared_ptr<SubscriberDelegate> subscriber_delegate,
                        const quicr::Namespace& quicr_namespace,
                        const SubscribeIntent& intent,
-                       const std::string& origin_url,
-                       bool use_reliable_transport,
-                       const std::string& auth_token,
-                       bytes&& e2e_token)
+                       [[maybe_unused]] const std::string& origin_url,
+                       [[maybe_unused]] bool use_reliable_transport,
+                       [[maybe_unused]] const std::string& auth_token,
+                       [[maybe_unused]] bytes&& e2e_token)
 {
 
   if (!sub_delegates.count(quicr_namespace)) {
@@ -148,18 +167,18 @@ QuicRClient::subscribe(std::shared_ptr<SubscriberDelegate> subscriber_delegate,
 }
 
 void
-QuicRClient::unsubscribe(const quicr::Namespace& quicr_namespace,
-                         const std::string& origin_url,
-                         const std::string& auth_token)
+QuicRClient::unsubscribe(const quicr::Namespace& /* quicr_namespace */,
+                         const std::string& /* origin_url */,
+                         const std::string& /* auth_token */)
 {
   throw std::runtime_error("UnImplemented");
 }
 
 void
 QuicRClient::publishNamedObject(const quicr::Name& quicr_name,
-                                uint8_t priority,
-                                uint16_t expiry_age_ms,
-                                bool use_reliable_transport,
+                                [[maybe_unused]] uint8_t priority,
+                                [[maybe_unused]] uint16_t expiry_age_ms,
+                                [[maybe_unused]] bool use_reliable_transport,
                                 bytes&& data)
 {
   // start populating message to encode
@@ -197,13 +216,13 @@ QuicRClient::publishNamedObject(const quicr::Name& quicr_name,
 }
 
 void
-QuicRClient::publishNamedObjectFragment(const quicr::Name& quicr_name,
-                                        uint8_t priority,
-                                        uint16_t expiry_age_ms,
-                                        bool use_reliable_transport,
-                                        const uint64_t& offset,
-                                        bool is_last_fragment,
-                                        bytes&& data)
+QuicRClient::publishNamedObjectFragment(const quicr::Name& /* quicr_name */,
+                                        uint8_t /* priority */,
+                                        uint16_t /* expiry_age_ms */,
+                                        bool /* use_reliable_transport */,
+                                        const uint64_t& /* offset */,
+                                        bool /* is_last_fragment */,
+                                        bytes&& /* data */)
 {
   throw std::runtime_error("UnImplemented");
 }

--- a/src/quicr_server.cpp
+++ b/src/quicr_server.cpp
@@ -11,6 +11,32 @@
 
 namespace quicr {
 
+void ServerDelegate::onPublishedFragment(const quicr::Name& /* quicr_name */,
+                                  uint8_t /* priority */,
+                                  uint16_t /* expiry_age_ms */,
+                                  bool /* use_reliable_transport */,
+                                  const uint64_t& /* offset */,
+                                  bool /* is_last_fragment */,
+                                  bytes&& /* data */)
+{
+}
+void ServerDelegate::onSubscribe(const quicr::Namespace& /* quicr_namespace */,
+                          const uint64_t& /* subscriber_id */,
+                          const SubscribeIntent /* subscribe_intent */,
+                          const std::string& /* origin_url */,
+                          bool /* use_reliable_transport */,
+                          const std::string& /* auth_token */,
+                          bytes&& /* data */)
+{
+}
+
+void ServerDelegate::onUnsubscribe(const quicr::Namespace& /* quicr_namespace */,
+                          const uint64_t& /* subscriber_id */,
+                          const std::string& /* auth_token */)
+{
+}
+
+
 /*
  * Start the  QUICR server at the port specified.
  *  @param delegate_in: Callback handlers for QUICR operations
@@ -18,8 +44,8 @@ namespace quicr {
 QuicRServer::QuicRServer(RelayInfo& relayInfo, ServerDelegate& delegate_in,
                          qtransport::LogHandler& logger)
   : delegate(delegate_in)
-  , transport_delegate(*this)
   , log_handler(logger)
+  , transport_delegate(*this)
 
 {
   t_relay.host_or_ip = relayInfo.hostname;
@@ -48,7 +74,7 @@ QuicRServer::QuicRServer(std::shared_ptr<qtransport::ITransport> transport_in,
 }
 
 std::shared_ptr<qtransport::ITransport>
-QuicRServer::setupTransport(RelayInfo& relayInfo)
+QuicRServer::setupTransport([[maybe_unused]] RelayInfo& relayInfo)
 {
   return qtransport::ITransport::make_server_transport(
     t_relay, transport_delegate, log_handler);
@@ -78,8 +104,8 @@ QuicRServer::run()
 }
 
 void
-QuicRServer::publishIntentResponse(const quicr::Namespace& quicr_namespace,
-                                   const PublishIntentResult& result)
+QuicRServer::publishIntentResponse(const quicr::Namespace& /* quicr_namespace */,
+                                   const PublishIntentResult& /* result */)
 {
   throw std::runtime_error("Unimplemented");
 }
@@ -100,8 +126,8 @@ QuicRServer::subscribeResponse(const quicr::Namespace& quicr_namespace,
 }
 
 void
-QuicRServer::subscriptionEnded(const quicr::Namespace& quicr_namespace,
-                               const SubscribeResult& result)
+QuicRServer::subscriptionEnded(const quicr::Namespace& /* quicr_namespace */,
+                               const SubscribeResult& /* result */)
 {
   throw std::runtime_error("Unimplemented");
 }
@@ -109,9 +135,9 @@ QuicRServer::subscriptionEnded(const quicr::Namespace& quicr_namespace,
 void
 QuicRServer::sendNamedObject(const uint64_t& subscriber_id,
                               const quicr::Name& quicr_name,
-                             uint8_t priority,
-                             uint64_t best_before,
-                             bool use_reliable_transport,
+                             [[maybe_unused]] uint8_t priority,
+                             [[maybe_unused]] uint64_t best_before,
+                             [[maybe_unused]] bool use_reliable_transport,
                              bytes&& data)
 {
   // start populating message to encode
@@ -140,13 +166,13 @@ QuicRServer::sendNamedObject(const uint64_t& subscriber_id,
 }
 
 void
-QuicRServer::sendNamedFragment(const quicr::Name& name,
-                               uint8_t priority,
-                               uint64_t best_before,
-                               bool use_reliable_transport,
-                               uint64_t offset,
-                               bool is_last_fragment,
-                               bytes&& data)
+QuicRServer::sendNamedFragment(const quicr::Name& /* name */,
+                               uint8_t /* priority */,
+                               uint64_t /* best_before */,
+                               bool /* use_reliable_transport */,
+                               uint64_t /* offset */,
+                               bool /* is_last_fragment */,
+                               bytes&& /* data */)
 {
   throw std::runtime_error("Unimplemented");
 }
@@ -187,8 +213,8 @@ QuicRServer::handle_subscribe(const qtransport::TransportContextId& context_id,
 }
 
 void
-QuicRServer::handle_publish(const qtransport::TransportContextId& context_id,
-                            const qtransport::MediaStreamId& mStreamId,
+QuicRServer::handle_publish([[maybe_unused]] const qtransport::TransportContextId& context_id,
+                            [[maybe_unused]] const qtransport::MediaStreamId& mStreamId,
                             messages::MessageBuffer&& msg)
 {
   messages::PublishDatagram datagram;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_options(quicr_test
 
 set_target_properties(quicr_test
     PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS ON)
 if(MSVC)

--- a/test/fake_transport.h
+++ b/test/fake_transport.h
@@ -7,23 +7,23 @@ struct FakeTransportDelegate : public ITransport::TransportDelegate
 {
   ~FakeTransportDelegate() = default;
 
-  virtual void on_connection_status(const TransportContextId& context_id,
-                                    const TransportStatus status) override
+  virtual void on_connection_status(const TransportContextId& /* context_id */,
+                                    const TransportStatus /* status */) override
   {
   }
 
-  virtual void on_new_connection(const TransportContextId& context_id,
-                                 const TransportRemote& remote) override
+  virtual void on_new_connection(const TransportContextId& /* context_id */,
+                                 const TransportRemote& /* remote */) override
   {
   }
 
-  virtual void on_new_media_stream(const TransportContextId& context_id,
-                                   const MediaStreamId& mStreamId) override
+  virtual void on_new_media_stream(const TransportContextId& /* context_id */,
+                                   const MediaStreamId& /* mStreamId */) override
   {
   }
 
-  void on_recv_notify(const TransportContextId& context_id,
-                      const MediaStreamId& mediaStreamId) override
+  void on_recv_notify(const TransportContextId& /* context_id */,
+                      const MediaStreamId& /* mediaStreamId */) override
   {
   }
 };
@@ -37,28 +37,28 @@ struct FakeTransport : public ITransport
 
   TransportStatus status() const { return TransportStatus::Ready; }
 
-  MediaStreamId createMediaStream(const TransportContextId& tcid,
-                                  bool use_reliable_transport)
+  MediaStreamId createMediaStream(const TransportContextId& /* tcid */,
+                                  bool /* use_reliable_transport */)
   {
     return 0x2000;
   }
 
-  void close(const TransportContextId& context_id){};
+  void close(const TransportContextId& /* context_id */){};
 
-  void closeMediaStream(const TransportContextId& context_id,
-                        MediaStreamId mStreamId){};
+  void closeMediaStream(const TransportContextId& /* context_id */,
+                        MediaStreamId /* mStreamId */){};
   void close() {}
 
-  TransportError enqueue(const TransportContextId& tcid,
-                         const MediaStreamId& msid,
+  TransportError enqueue(const TransportContextId& /* tcid */,
+                         const MediaStreamId& /* msid */,
                          std::vector<uint8_t>&& bytes)
   {
     stored_data = std::move(bytes);
     return TransportError::None;
   }
 
-  std::optional<std::vector<uint8_t>> dequeue(const TransportContextId& tcid,
-                                              const MediaStreamId& msid)
+  std::optional<std::vector<uint8_t>> dequeue(const TransportContextId& /* tcid */,
+                                              const MediaStreamId& /* msid */)
   {
     return std::nullopt;
   }

--- a/test/quicr_client.cpp
+++ b/test/quicr_client.cpp
@@ -15,39 +15,39 @@ struct TestSubscriberDelegate : public SubscriberDelegate
   TestSubscriberDelegate() = default;
   ~TestSubscriberDelegate() = default;
 
-  void onSubscribeResponse(const quicr::Namespace& quicr_namespace,
-                           const SubscribeResult& result)
+  void onSubscribeResponse(const quicr::Namespace& /* quicr_namespace */,
+                           const SubscribeResult::SubscribeStatus& /* result */)
   {
   }
 
-  void onSubscriptionEnded(const quicr::Namespace& quicr_namespace,
-                           const SubscribeResult& result)
+  void onSubscriptionEnded(const quicr::Namespace& /* quicr_namespace */,
+                           const SubscribeResult& /* result */)
   {
   }
 
-  void onSubscribedObject(const quicr::Name& quicr_name,
-                          uint8_t priority,
-                          uint16_t expiry_age_ms,
-                          bool use_reliable_transport,
-                          bytes&& data)
+  void onSubscribedObject(const quicr::Name& /* quicr_name */,
+                          uint8_t /* priority */,
+                          uint16_t /* expiry_age_ms */,
+                          bool /* use_reliable_transport */,
+                          bytes&& /* data */)
   {
   }
 
-  void onSubscribedObjectFragment(const quicr::Name& quicr_name,
-                                  uint8_t priority,
-                                  uint16_t expiry_age_ms,
-                                  bool use_reliable_transport,
-                                  const uint64_t& offset,
-                                  bool is_last_fragment,
-                                  bytes&& data)
+  void onSubscribedObjectFragment(const quicr::Name& /* quicr_name */,
+                                  uint8_t /* priority */,
+                                  uint16_t /* expiry_age_ms */,
+                                  bool /* use_reliable_transport */,
+                                  const uint64_t& /* offset */,
+                                  bool /* is_last_fragment */,
+                                  bytes&& /* data */)
   {
   }
 };
 
 struct TestPublisherDelegate : public PublisherDelegate
 {
-  void onPublishIntentResponse(const quicr::Namespace& quicr_namespace,
-                               const PublishIntentResult& result) override
+  void onPublishIntentResponse(const quicr::Namespace& /* quicr_namespace */,
+                               const PublishIntentResult& /* result */) override
   {
   }
 

--- a/test/quicr_server.cpp
+++ b/test/quicr_server.cpp
@@ -12,38 +12,39 @@ using namespace quicr;
 class TestServerDelegate : public ServerDelegate
 {
 
-  virtual void onPublishIntent(const quicr::Namespace& quicr_name,
-                               const std::string& origin_url,
-                               bool use_reliable_transport,
-                               const std::string& auth_token,
-                               bytes&& e2e_token) override
+  virtual void onPublishIntent(const quicr::Namespace& /* quicr_name */,
+                               const std::string& /* origin_url */,
+                               bool /* use_reliable_transport */,
+                               const std::string& /* auth_token */,
+                               bytes&& /* e2e_token */) override
   {
   }
 
-  virtual void onPublisherObject(const quicr::Name& quicr_name,
-                                 uint8_t priority,
-                                 uint16_t expiry_age_ms,
-                                 bool use_reliable_transport,
-                                 bytes&& data) override
+  virtual void onPublisherObject(const quicr::Name& /* quicr_name */,
+                                 uint8_t /* priority */,
+                                 uint16_t /* expiry_age_ms */,
+                                 bool /* use_reliable_transport */,
+                                 bytes&& /* data */) override
   {
   }
 
-  virtual void onPublishedFragment(const quicr::Name& quicr_name,
-                                   uint8_t priority,
-                                   uint16_t expiry_age_ms,
-                                   bool use_reliable_transport,
-                                   const uint64_t& offset,
-                                   bool is_last_fragment,
-                                   bytes&& data)
+  virtual void onPublishedFragment(const quicr::Name& /* quicr_name */,
+                                   uint8_t /* priority */,
+                                   uint16_t /* expiry_age_ms */,
+                                   bool /* use_reliable_transport */,
+                                   const uint64_t& /* offset */,
+                                   bool /* is_last_fragment */,
+                                   bytes&& /* data */) override
   {
   }
 
-  virtual void onSubscribe(const quicr::Namespace& quicr_namespace,
-                           const SubscribeIntent subscribe_intent,
-                           const std::string& origin_url,
-                           bool use_reliable_transport,
-                           const std::string& auth_token,
-                           bytes&& data)
+  virtual void onSubscribe(const quicr::Namespace& /* quicr_namespace */,
+                           const uint64_t& /* subscriber_id */,
+                           const SubscribeIntent /* subscribe_intent */,
+                           const std::string& /* origin_url */,
+                           bool /* use_reliable_transport */,
+                           const std::string& /* auth_token */,
+                           bytes&& /* data */) override
   {
   }
 };
@@ -53,9 +54,9 @@ TEST_CASE("Object Lifetime")
   TestServerDelegate delegate{};
   FakeTransport fake_transport;
   RelayInfo relayInfo = {
-    hostname : "127.0.0.1",
-    port : 1234,
-    proto : RelayInfo::Protocol::UDP
+    .hostname = "127.0.0.1",
+    .port = 1234,
+    .proto = RelayInfo::Protocol::UDP
   };
   qtransport::LogHandler logger;
   CHECK_NOTHROW(std::make_unique<QuicRServer>(relayInfo,


### PR DESCRIPTION
Trying to reduce the tsunami of unused warnings. The general rule for what I've done in this PR:
- If it's unimplemented, comment the name out (so it's still obvious what it is, but it doesn't cause compiler warnings)
- If it already has a partial implementation, mark the unused params as [[maybe_unused]]

Also moved default empty implementations into .cpp files (if possible).