### PR TITLE
Improve msgbuffer

### DIFF
--- a/benchmark/message_buffer.cpp
+++ b/benchmark/message_buffer.cpp
@@ -18,7 +18,16 @@ void BM_MessageBufferPushBack(benchmark::State& state)
     quicr::messages::MessageBuffer buffer;
     for (auto _ : state)
     {
-        buffer.push(uint8_t(std::rand() % 100));
+        buffer << uint8_t(std::rand() % 100);
+    }
+}
+
+void BM_MessageBufferPushBack64(benchmark::State& state)
+{
+    quicr::messages::MessageBuffer buffer;
+    for (auto _ : state)
+    {
+        buffer << uint64_t(std::rand() % 100);
     }
 }
 
@@ -49,5 +58,6 @@ void BM_MessageBufferPushBackMoveVector(benchmark::State& state)
 
 BENCHMARK(BM_MessageBufferConstruct);
 BENCHMARK(BM_MessageBufferPushBack);
+BENCHMARK(BM_MessageBufferPushBack64);
 BENCHMARK(BM_MessageBufferPushBackVector);
 BENCHMARK(BM_MessageBufferPushBackMoveVector);

--- a/benchmark/message_buffer.cpp
+++ b/benchmark/message_buffer.cpp
@@ -1,63 +1,61 @@
 #include <benchmark/benchmark.h>
 
+#include <quicr/encode.h>
 #include <quicr/message_buffer.h>
 
-void BM_MessageBufferConstruct(benchmark::State& state)
+void
+BM_MessageBufferConstruct(benchmark::State& state)
 {
-    std::vector<uint8_t> buffer(1280);
-    std::generate(buffer.begin(), buffer.end(), std::rand);
+  std::vector<uint8_t> buffer(1280);
+  std::generate(buffer.begin(), buffer.end(), std::rand);
 
-    for (auto _ : state)
-    {
-        quicr::messages::MessageBuffer __(buffer);
-    }
+  for (auto _ : state) {
+    quicr::messages::MessageBuffer __(buffer);
+  }
 }
 
-void BM_MessageBufferPushBack(benchmark::State& state)
+void
+BM_MessageBufferPushBack(benchmark::State& state)
 {
-    quicr::messages::MessageBuffer buffer;
-    for (auto _ : state)
-    {
-        buffer << uint8_t(std::rand() % 100);
-    }
+  quicr::messages::MessageBuffer buffer;
+  for (auto _ : state) {
+    buffer << uint8_t(std::rand() % 100);
+  }
 }
 
-void BM_MessageBufferPushBack64(benchmark::State& state)
+void
+BM_MessageBufferPushBack64(benchmark::State& state)
 {
-    quicr::messages::MessageBuffer buffer;
-    for (auto _ : state)
-    {
-        buffer << uint64_t(std::rand() % 100);
-    }
+  quicr::messages::MessageBuffer buffer;
+  for (auto _ : state) {
+    buffer << uint64_t(std::rand() % 100);
+  }
 }
 
-void BM_MessageBufferPushBackVector(benchmark::State& state)
+void
+BM_MessageBufferPushBackVector(benchmark::State& state)
 {
-    std::vector<uint8_t> buf(1280);
-    std::generate(buf.begin(), buf.end(), std::rand);
+  std::vector<uint8_t> buf(1280);
+  std::generate(buf.begin(), buf.end(), std::rand);
 
-    quicr::messages::MessageBuffer buffer;
-    for (auto _ : state)
-    {
-        buffer.push(buf);
-    }
+  quicr::messages::MessageBuffer buffer(1280 * 1000);
+  for (auto _ : state) {
+    buffer.push(buf);
+  }
 }
 
-void BM_MessageBufferPushBackMoveVector(benchmark::State& state)
+void
+BM_MessageBufferWriteName(benchmark::State& state)
 {
-    quicr::messages::MessageBuffer buffer;
-    for (auto _ : state)
-    {
-        state.PauseTiming();
-        std::vector<uint8_t> buf(1280);
-        std::generate(buf.begin(), buf.end(), std::rand);
-        state.ResumeTiming();
-        buffer.push(std::move(buf));
-    }
+  quicr::messages::MessageBuffer buffer;
+  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  for (auto _ : state) {
+    buffer << name;
+  }
 }
 
 BENCHMARK(BM_MessageBufferConstruct);
 BENCHMARK(BM_MessageBufferPushBack);
 BENCHMARK(BM_MessageBufferPushBack64);
 BENCHMARK(BM_MessageBufferPushBackVector);
-BENCHMARK(BM_MessageBufferPushBackMoveVector);
+BENCHMARK(BM_MessageBufferWriteName);

--- a/benchmark/message_buffer.cpp
+++ b/benchmark/message_buffer.cpp
@@ -18,7 +18,7 @@ void BM_MessageBufferPushBack(benchmark::State& state)
     quicr::messages::MessageBuffer buffer;
     for (auto _ : state)
     {
-        buffer.push_back(uint8_t(std::rand() % 100));
+        buffer.push(uint8_t(std::rand() % 100));
     }
 }
 
@@ -30,10 +30,24 @@ void BM_MessageBufferPushBackVector(benchmark::State& state)
     quicr::messages::MessageBuffer buffer;
     for (auto _ : state)
     {
-        buffer.push_back(buf);
+        buffer.push(buf);
+    }
+}
+
+void BM_MessageBufferPushBackMoveVector(benchmark::State& state)
+{
+    quicr::messages::MessageBuffer buffer;
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        std::vector<uint8_t> buf(1280);
+        std::generate(buf.begin(), buf.end(), std::rand);
+        state.ResumeTiming();
+        buffer.push(std::move(buf));
     }
 }
 
 BENCHMARK(BM_MessageBufferConstruct);
 BENCHMARK(BM_MessageBufferPushBack);
 BENCHMARK(BM_MessageBufferPushBackVector);
+BENCHMARK(BM_MessageBufferPushBackMoveVector);

--- a/benchmark/name.cpp
+++ b/benchmark/name.cpp
@@ -15,7 +15,7 @@ static void BM_NameCopyConstruct(benchmark::State& state)
     quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
     for (auto _ : state)
     {
-        quicr::Name __(name);
+        [[maybe_unused]] quicr::Name __(name);
     }
 }
 

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -128,7 +128,7 @@ struct PublishIntent
 };
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntent& msg);
+operator<<(MessageBuffer& buffer, PublishIntent&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntent& msg);
 
@@ -171,7 +171,7 @@ struct PublishDatagram
 };
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishDatagram& msg);
+operator<<(MessageBuffer& buffer, PublishDatagram&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishDatagram& msg);
 
@@ -182,22 +182,21 @@ struct PublishStream
 };
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishStream& msg);
+operator<<(MessageBuffer& buffer, PublishStream&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishStream& msg);
 
 struct PublishIntentEnd
 {
   MessageType message_type;
-  uintVar_t name_length;
-  std::vector<uint8_t> name;
+  quicr::Name name;
   //  * relay_auth_token_length(i),
   //  * relay_token(…),
   std::vector<uint8_t> payload;
 };
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg);
+operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
 

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -1,12 +1,13 @@
 #pragma once
-#include <random>
-#include <string>
-#include <vector>
 
 #include <quicr/message_buffer.h>
 #include <quicr/quicr_common.h>
 #include <quicr/quicr_name.h>
 #include <quicr/quicr_namespace.h>
+
+#include <random>
+#include <string>
+#include <vector>
 
 /**
  *  Utilties to encode and decode protocol messages

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -128,6 +128,8 @@ struct PublishIntent
 };
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntent& msg);
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntent&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntent& msg);
@@ -171,6 +173,8 @@ struct PublishDatagram
 };
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishDatagram& msg);
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishDatagram&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishDatagram& msg);
@@ -181,6 +185,8 @@ struct PublishStream
   std::vector<uint8_t> media_data;
 };
 
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishStream& msg);
 MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishStream&& msg);
 MessageBuffer&
@@ -196,18 +202,20 @@ struct PublishIntentEnd
 };
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg);
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
 
-messages::MessageBuffer&
-operator<<(messages::MessageBuffer& msg, const Name& ns);
-messages::MessageBuffer&
-operator>>(messages::MessageBuffer& msg, Name& ns);
+MessageBuffer&
+operator<<(MessageBuffer& msg, const Name& ns);
+MessageBuffer&
+operator>>(MessageBuffer& msg, Name& ns);
 
-messages::MessageBuffer&
-operator<<(messages::MessageBuffer& msg, const Namespace& ns);
-messages::MessageBuffer&
-operator>>(messages::MessageBuffer& msg, Namespace& ns);
+MessageBuffer&
+operator<<(MessageBuffer& msg, const Namespace& ns);
+MessageBuffer&
+operator>>(MessageBuffer& msg, Namespace& ns);
 
 }

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -3,6 +3,8 @@
 #include <quicr/quicr_name.h>
 #include <quicr/quicr_namespace.h>
 
+#include <cassert>
+#include <deque>
 #include <vector>
 
 namespace quicr {
@@ -24,26 +26,24 @@ class MessageBuffer
 {
 public:
   MessageBuffer() = default;
+  MessageBuffer(const MessageBuffer& other) = delete;
   MessageBuffer(MessageBuffer&& other);
   MessageBuffer(const std::vector<uint8_t>& buffer);
   MessageBuffer(std::vector<uint8_t>&& buffer);
-  MessageBuffer(const MessageBuffer& other) = delete;
   ~MessageBuffer() = default;
 
   bool empty() const { return _buffer.empty(); }
 
-  void push_back(uint8_t t) { _buffer.push_back(t); }
-  void pop_back() { _buffer.pop_back(); }
-  uint8_t back() const { return _buffer.back(); }
+  void push(uint8_t t) { _buffer.push_back(t); }
+  void pop();
+  uint8_t front() const { return _buffer.front(); }
 
-  void push_back(const std::vector<uint8_t>& data);
-  void pop_back(uint16_t len);
-  std::vector<uint8_t> back(uint16_t len);
+  void push(const std::vector<uint8_t>& data);
+  void push(std::vector<uint8_t>&& data);
+  void pop(uint16_t len);
+  std::vector<uint8_t> front(uint16_t len);
 
-  /**
-   * @brief Returns an rvalue reference to the buffer (moving it).
-   */
-  std::vector<uint8_t>&& get() { return std::move(_buffer); }
+  std::vector<uint8_t> get();
 
   std::string to_hex() const;
 

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -32,30 +32,12 @@ public:
     return *this;
   }
 
-  constexpr bool operator==(uintVar_t other)
-  {
-    return _value == other._value;
-  }
-  constexpr bool operator!=(uintVar_t other)
-  {
-    return !(*this == other);
-  }
-  constexpr bool operator>(uintVar_t other)
-  {
-    return _value > other._value;
-  }
-  constexpr bool operator>=(uintVar_t other)
-  {
-    return _value >= other._value;
-  }
-  constexpr bool operator<(uintVar_t other)
-  {
-    return _value < other._value;
-  }
-  constexpr bool operator<=(uintVar_t other)
-  {
-    return _value <= other._value;
-  }
+  constexpr bool operator==(uintVar_t other) { return _value == other._value; }
+  constexpr bool operator!=(uintVar_t other) { return !(*this == other); }
+  constexpr bool operator>(uintVar_t other) { return _value > other._value; }
+  constexpr bool operator>=(uintVar_t other) { return _value >= other._value; }
+  constexpr bool operator<(uintVar_t other) { return _value < other._value; }
+  constexpr bool operator<=(uintVar_t other) { return _value <= other._value; }
 
   friend std::ostream& operator<<(std::ostream& os, uintVar_t v)
   {
@@ -76,7 +58,8 @@ class MessageBuffer
 {
 public:
   MessageBuffer() = default;
-  MessageBuffer(const MessageBuffer& other) = delete;
+  MessageBuffer(size_t reserve_size) { _buffer.reserve(reserve_size); }
+  MessageBuffer(const MessageBuffer& other) = default;
   MessageBuffer(MessageBuffer&& other);
   MessageBuffer(const std::vector<uint8_t>& buffer);
   MessageBuffer(std::vector<uint8_t>&& buffer);
@@ -86,7 +69,7 @@ public:
 
   void push(uint8_t t) { _buffer.push_back(t); }
   void pop();
-  uint8_t front() const { return _buffer.front(); }
+  const uint8_t& front() const { return _buffer.front(); }
 
   void push(const std::vector<uint8_t>& data);
   void push(std::vector<uint8_t>&& data);

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -77,6 +77,8 @@ operator>>(MessageBuffer& msg, uintVar_t& val);
 MessageBuffer&
 operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val);
 MessageBuffer&
+operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val);
+MessageBuffer&
 operator>>(MessageBuffer& msg, std::vector<uint8_t>& val);
 }
 }

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -32,29 +32,29 @@ public:
     return *this;
   }
 
-  friend constexpr bool operator==(uintVar_t a, uintVar_t b)
+  constexpr bool operator==(uintVar_t other)
   {
-    return a._value == b._value;
+    return _value == other._value;
   }
-  friend constexpr bool operator!=(uintVar_t a, uintVar_t b)
+  constexpr bool operator!=(uintVar_t other)
   {
-    return !(a == b);
+    return !(*this == other);
   }
-  friend constexpr bool operator>(uintVar_t a, uintVar_t b)
+  constexpr bool operator>(uintVar_t other)
   {
-    return a._value > b._value;
+    return _value > other._value;
   }
-  friend constexpr bool operator>=(uintVar_t a, uintVar_t b)
+  constexpr bool operator>=(uintVar_t other)
   {
-    return a._value >= b._value;
+    return _value >= other._value;
   }
-  friend constexpr bool operator<(uintVar_t a, uintVar_t b)
+  constexpr bool operator<(uintVar_t other)
   {
-    return a._value < b._value;
+    return _value < other._value;
   }
-  friend constexpr bool operator<=(uintVar_t a, uintVar_t b)
+  constexpr bool operator<=(uintVar_t other)
   {
-    return a._value <= b._value;
+    return _value <= other._value;
   }
 
   friend std::ostream& operator<<(std::ostream& os, uintVar_t v)
@@ -65,19 +65,6 @@ public:
 private:
   uint64_t _value;
 };
-
-[[deprecated("uint64_t is explicitly convertible to uintVar_t. Use assignment "
-             "operator instead")]] inline uintVar_t
-to_varint(uint64_t v)
-{
-  return v;
-}
-[[deprecated("uintVar_t is implicitly convertible to uint64_t. Use assignment "
-             "operator instead")]] inline uint64_t
-from_varint(uintVar_t v)
-{
-  return v;
-}
 }
 
 namespace quicr::messages {

--- a/include/quicr/quicr_name.h
+++ b/include/quicr/quicr_name.h
@@ -13,12 +13,13 @@ class MessageBuffer;
 
 class Name
 {
-public:
   using uint_type = uint64_t;
 
+public:
+
   Name();
-  Name(const Name& other);
-  Name(Name&& other);
+  Name(const Name& other) = default;
+  Name(Name&& other) = default;
   Name(const std::string& hex_value);
   Name(uint8_t* data, size_t length);
   Name(const uint8_t* data, size_t length);

--- a/include/quicr/quicr_name.h
+++ b/include/quicr/quicr_name.h
@@ -16,9 +16,8 @@ class Name
   using uint_type = uint64_t;
 
 public:
-
-  Name();
-  Name(const Name& other) = default;
+  constexpr Name() = default;
+  constexpr Name(const Name& other) = default;
   Name(Name&& other) = default;
   Name(const std::string& hex_value);
   Name(uint8_t* data, size_t length);
@@ -54,8 +53,8 @@ public:
   void operator^=(const Name& other);
   Name operator~() const;
 
-  Name& operator=(const Name& other);
-  Name& operator=(Name&& other);
+  constexpr Name& operator=(const Name& other) = default;
+  constexpr Name& operator=(Name&& other) = default;
 
   friend bool operator<(const Name& a, const Name& b);
   friend bool operator>(const Name& a, const Name& b);
@@ -65,8 +64,8 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const Name& name);
 
 private:
-  uint_type _hi;
-  uint_type _low;
+  uint_type _hi{ 0 };
+  uint_type _low{ 0 };
 };
 
 struct NameException : public std::runtime_error

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -138,6 +138,19 @@ operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
 /*===========================================================================*/
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntent& msg)
+{
+  buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+  buffer << msg.mask;
+  buffer << msg.payload;
+  buffer << msg.media_id;
+  buffer << msg.datagram_capable;
+  return buffer;
+}
+
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntent&& msg)
 {
   buffer << static_cast<uint8_t>(msg.message_type);
@@ -220,6 +233,18 @@ operator>>(MessageBuffer& buffer, Header& msg)
 }
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishDatagram& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Publish);
+  buffer << msg.header;
+  buffer << static_cast<uint8_t>(msg.media_type);
+  buffer << msg.media_data_length;
+  buffer << msg.media_data;
+
+  return buffer;
+}
+
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishDatagram&& msg)
 {
   buffer << static_cast<uint8_t>(MessageType::Publish);
@@ -259,6 +284,14 @@ operator>>(MessageBuffer& buffer, PublishDatagram& msg)
 }
 
 MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishStream& msg)
+{
+  buffer << msg.media_data_length;
+  buffer << msg.media_data;
+  return buffer;
+}
+
+MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishStream&& msg)
 {
   buffer << msg.media_data_length;
@@ -275,6 +308,16 @@ operator>>(MessageBuffer& buffer, PublishStream& msg)
     throw MessageBufferException(
       "PublishStream size of decoded media data must match decoded length");
   }
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg)
+{
+  buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.name;
+  buffer << msg.payload;
 
   return buffer;
 }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -52,8 +52,8 @@ operator>>(MessageBuffer& buffer, Subscribe& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const Unsubscribe& msg)
 {
-  buffer << msg.quicr_namespace;
   buffer << static_cast<uint8_t>(MessageType::Unsubscribe);
+  buffer << msg.quicr_namespace;
 
   return buffer;
 }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <ctime>
+#include <string>
 
 #include <quicr/encode.h>
 
@@ -21,10 +22,10 @@ transaction_id()
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const Subscribe& msg)
 {
-  buffer << static_cast<uint8_t>(msg.intent);
-  buffer << msg.quicr_namespace;
-  buffer << msg.transaction_id;
   buffer << static_cast<uint8_t>(MessageType::Subscribe);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+  buffer << static_cast<uint8_t>(msg.intent);
 
   return buffer;
 }
@@ -75,10 +76,10 @@ operator>>(MessageBuffer& buffer, Unsubscribe& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const SubscribeResponse& msg)
 {
-  buffer << msg.quicr_namespace;
-  buffer << msg.transaction_id;
-  buffer << static_cast<uint8_t>(msg.response);
   buffer << static_cast<uint8_t>(MessageType::SubscribeResponse);
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
 
   return buffer;
 }
@@ -106,9 +107,9 @@ operator>>(MessageBuffer& buffer, SubscribeResponse& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const SubscribeEnd& msg)
 {
-  buffer << msg.quicr_namespace;
-  buffer << static_cast<uint8_t>(msg.reason);
   buffer << static_cast<uint8_t>(MessageType::SubscribeEnd);
+  buffer << static_cast<uint8_t>(msg.reason);
+  buffer << msg.quicr_namespace;
 
   return buffer;
 }
@@ -139,13 +140,13 @@ operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntent& msg)
 {
-  buffer << msg.datagram_capable;
-  buffer << msg.media_id;
-  buffer << msg.payload;
-  buffer << msg.mask;
-  buffer << msg.quicr_namespace;
-  buffer << msg.transaction_id;
   buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+  buffer << msg.mask;
+  buffer << msg.payload;
+  buffer << msg.media_id;
+  buffer << msg.datagram_capable;
   return buffer;
 }
 
@@ -169,9 +170,9 @@ operator>>(MessageBuffer& buffer, PublishIntent& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg)
 {
-  buffer << msg.transaction_id;
-  buffer << static_cast<uint8_t>(msg.response);
   buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
 
   return buffer;
 }
@@ -195,12 +196,12 @@ operator>>(MessageBuffer& buffer, PublishIntentResponse& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const Header& msg)
 {
-  buffer << msg.flags;
-  buffer << msg.offset_and_fin;
-  buffer << msg.object_id;
-  buffer << msg.group_id;
-  buffer << msg.media_id;
   buffer << msg.name;
+  buffer << msg.media_id;
+  buffer << msg.group_id;
+  buffer << msg.object_id;
+  buffer << msg.offset_and_fin;
+  buffer << msg.flags;
 
   return buffer;
 }
@@ -221,11 +222,11 @@ operator>>(MessageBuffer& buffer, Header& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishDatagram& msg)
 {
-  buffer << msg.media_data;
-  buffer << msg.media_data_length;
-  buffer << static_cast<uint8_t>(msg.media_type);
-  buffer << msg.header;
   buffer << static_cast<uint8_t>(MessageType::Publish);
+  buffer << msg.header;
+  buffer << static_cast<uint8_t>(msg.media_type);
+  buffer << msg.media_data_length;
+  buffer << msg.media_data;
 
   return buffer;
 }
@@ -260,8 +261,8 @@ operator>>(MessageBuffer& buffer, PublishDatagram& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishStream& msg)
 {
-  buffer << msg.media_data;
   buffer << msg.media_data_length;
+  buffer << msg.media_data;
   return buffer;
 }
 
@@ -281,10 +282,10 @@ operator>>(MessageBuffer& buffer, PublishStream& msg)
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg)
 {
-  buffer << msg.payload;
-  buffer << msg.name;
-  buffer << msg.name_length;
   buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.name_length;
+  buffer << msg.name;
+  buffer << msg.payload;
 
   return buffer;
 }
@@ -313,7 +314,7 @@ operator<<(messages::MessageBuffer& msg, const quicr::Name& val)
 {
   constexpr uint8_t size = quicr::Name::size();
   for (size_t i = 0; i < size; ++i)
-    msg << val[size - 1 - i];
+    msg << val[i];
 
   return msg;
 }
@@ -334,7 +335,7 @@ operator>>(messages::MessageBuffer& msg, quicr::Name& val)
 messages::MessageBuffer&
 operator<<(messages::MessageBuffer& msg, const quicr::Namespace& val)
 {
-  msg << val.length() << val.name();
+  msg << val.name() << val.length();
   return msg;
 }
 

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -138,13 +138,13 @@ operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
 /*===========================================================================*/
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntent& msg)
+operator<<(MessageBuffer& buffer, PublishIntent&& msg)
 {
   buffer << static_cast<uint8_t>(msg.message_type);
   buffer << msg.transaction_id;
   buffer << msg.quicr_namespace;
   buffer << msg.mask;
-  buffer << msg.payload;
+  buffer << std::move(msg.payload);
   buffer << msg.media_id;
   buffer << msg.datagram_capable;
   return buffer;
@@ -220,13 +220,13 @@ operator>>(MessageBuffer& buffer, Header& msg)
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishDatagram& msg)
+operator<<(MessageBuffer& buffer, PublishDatagram&& msg)
 {
   buffer << static_cast<uint8_t>(MessageType::Publish);
-  buffer << msg.header;
+  buffer << std::move(msg.header);
   buffer << static_cast<uint8_t>(msg.media_type);
   buffer << msg.media_data_length;
-  buffer << msg.media_data;
+  buffer << std::move(msg.media_data);
 
   return buffer;
 }
@@ -259,10 +259,10 @@ operator>>(MessageBuffer& buffer, PublishDatagram& msg)
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishStream& msg)
+operator<<(MessageBuffer& buffer, PublishStream&& msg)
 {
   buffer << msg.media_data_length;
-  buffer << msg.media_data;
+  buffer << std::move(msg.media_data);
   return buffer;
 }
 
@@ -280,12 +280,11 @@ operator>>(MessageBuffer& buffer, PublishStream& msg)
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg)
+operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg)
 {
   buffer << static_cast<uint8_t>(msg.message_type);
-  buffer << msg.name_length;
   buffer << msg.name;
-  buffer << msg.payload;
+  buffer << std::move(msg.payload);
 
   return buffer;
 }
@@ -297,13 +296,7 @@ operator>>(MessageBuffer& buffer, PublishIntentEnd& msg)
   buffer >> msg_type;
   msg.message_type = static_cast<MessageType>(msg_type);
 
-  buffer >> msg.name_length;
   buffer >> msg.name;
-
-  if (msg.name.size() != static_cast<size_t>(msg.name_length))
-    throw MessageBufferException(
-      "PublishIntentEnd size of decoded media data must match decoded length");
-
   buffer >> msg.payload;
 
   return buffer;

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -103,7 +103,6 @@ swap_bytes(uint64_t value)
   if constexpr (std::endian::native == std::endian::big)
     return value;
 
-#ifndef htonll
   return ((((value) >> 56) & 0x00000000000000ff) |
           (((value) >> 40) & 0x000000000000ff00) |
           (((value) >> 24) & 0x0000000000ff0000) |
@@ -112,9 +111,6 @@ swap_bytes(uint64_t value)
           (((value) << 24) & 0x0000ff0000000000) |
           (((value) << 40) & 0x00ff000000000000) |
           (((value) << 56) & 0xff00000000000000));
-#else
-  return htonll(value);
-#endif
 }
 
 template<typename Uint_t>

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -34,7 +34,7 @@ MessageBuffer::pop()
 void
 MessageBuffer::push(const std::vector<uint8_t>& data)
 {
-  std::copy(data.begin(), data.end(), std::back_inserter(_buffer));
+  _buffer.insert(_buffer.end(), data.begin(), data.end());
 }
 
 void
@@ -89,17 +89,14 @@ MessageBuffer::operator=(MessageBuffer&& other)
 constexpr uint16_t
 swap_bytes(uint16_t value)
 {
-  return ((value >>  8) & 0x00ff) |
-         ((value <<  8) & 0xff00);
+  return ((value >> 8) & 0x00ff) | ((value << 8) & 0xff00);
 }
 
 constexpr uint32_t
 swap_bytes(uint32_t value)
 {
-  return ((value >> 24) & 0x000000ff) |
-         ((value >>  8) & 0x0000ff00) |
-         ((value <<  8) & 0x00ff0000) |
-         ((value << 24) & 0xff000000);
+  return ((value >> 24) & 0x000000ff) | ((value >> 8) & 0x0000ff00) |
+         ((value << 8) & 0x00ff0000) | ((value << 24) & 0xff000000);
 }
 
 constexpr uint64_t
@@ -111,8 +108,8 @@ swap_bytes(uint64_t value)
   return ((value >> 56) & 0x00000000000000ff) |
          ((value >> 40) & 0x000000000000ff00) |
          ((value >> 24) & 0x0000000000ff0000) |
-         ((value >>  8) & 0x00000000ff000000) |
-         ((value <<  8) & 0x000000ff00000000) |
+         ((value >> 8) & 0x00000000ff000000) |
+         ((value << 8) & 0x000000ff00000000) |
          ((value << 24) & 0x0000ff0000000000) |
          ((value << 40) & 0x00ff000000000000) |
          ((value << 56) & 0xff00000000000000);

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -164,6 +164,14 @@ operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val)
 }
 
 MessageBuffer&
+operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val)
+{
+  msg << to_varint(val.size());
+  msg.push(std::move(val));
+  return msg;
+}
+
+MessageBuffer&
 operator>>(MessageBuffer& msg, std::vector<uint8_t>& val)
 {
   uintVar_t vecSize{ 0 };

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -134,7 +134,7 @@ operator<<(MessageBuffer& msg, uint8_t val)
 }
 
 #ifndef ntohll
-#define htonll(x) ((static_cast<uint64_t>(htonl(x)) << 32) + htonl((x) >> 32))
+#define ntohll(x) ((static_cast<uint64_t>(htonl(x)) << 32) + htonl((x) >> 32))
 #endif
 uint16_t
 ntoh(uint16_t value)

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -7,7 +7,6 @@
 #include <iomanip>
 #include <sstream>
 #include <vector>
-#include <arpa/inet.h>
 
 namespace quicr::messages {
 MessageBuffer::MessageBuffer(MessageBuffer&& other)
@@ -90,13 +89,19 @@ MessageBuffer::operator=(MessageBuffer&& other)
 constexpr uint16_t
 swap_bytes(uint16_t value)
 {
-  return htons(value);
+  return ((value >>  8) & 0x00ff) |
+         ((value <<  8) & 0xff00);
 }
+
 constexpr uint32_t
 swap_bytes(uint32_t value)
 {
-  return htonl(value);
+  return ((value >> 24) & 0x000000ff) |
+         ((value >>  8) & 0x0000ff00) |
+         ((value <<  8) & 0x00ff0000) |
+         ((value << 24) & 0xff000000);
 }
+
 constexpr uint64_t
 swap_bytes(uint64_t value)
 {

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -103,14 +103,14 @@ swap_bytes(uint64_t value)
   if constexpr (std::endian::native == std::endian::big)
     return value;
 
-  return ((((value) >> 56) & 0x00000000000000ff) |
-          (((value) >> 40) & 0x000000000000ff00) |
-          (((value) >> 24) & 0x0000000000ff0000) |
-          (((value) >>  8) & 0x00000000ff000000) |
-          (((value) <<  8) & 0x000000ff00000000) |
-          (((value) << 24) & 0x0000ff0000000000) |
-          (((value) << 40) & 0x00ff000000000000) |
-          (((value) << 56) & 0xff00000000000000));
+  return ((value >> 56) & 0x00000000000000ff) |
+         ((value >> 40) & 0x000000000000ff00) |
+         ((value >> 24) & 0x0000000000ff0000) |
+         ((value >>  8) & 0x00000000ff000000) |
+         ((value <<  8) & 0x000000ff00000000) |
+         ((value << 24) & 0x0000ff0000000000) |
+         ((value << 40) & 0x00ff000000000000) |
+         ((value << 56) & 0xff00000000000000);
 }
 
 template<typename Uint_t>

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -7,6 +7,7 @@
 #include <iomanip>
 #include <sstream>
 #include <vector>
+#include <arpa/inet.h>
 
 namespace quicr::messages {
 MessageBuffer::MessageBuffer(MessageBuffer&& other)

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -140,9 +140,7 @@ QuicRClient::QuicRClient(std::shared_ptr<ITransport> transport_in)
   transport = transport_in;
 }
 
-QuicRClient::~QuicRClient() {
-
-}
+QuicRClient::~QuicRClient() {}
 
 bool
 QuicRClient::publishIntent(
@@ -213,7 +211,7 @@ QuicRClient::unsubscribe(const quicr::Namespace& quicr_namespace,
   // The removal of the delegate is done on receive of subscription ended
 
   messages::MessageBuffer msg{};
-  messages::Unsubscribe unsub { 0x1, quicr_namespace };
+  messages::Unsubscribe unsub{ 0x1, quicr_namespace };
   msg << unsub;
 
   if (subscribe_state.count(quicr_namespace)) {
@@ -221,7 +219,6 @@ QuicRClient::unsubscribe(const quicr::Namespace& quicr_namespace,
   }
 
   transport->enqueue(transport_context_id, media_stream_id, msg.get());
-
 }
 
 void
@@ -280,15 +277,15 @@ QuicRClient::publishNamedObject(const quicr::Name& quicr_name,
       messages::MessageBuffer msg;
 
       if (frag_num == 0 && !frag_remaining_bytes) {
-        datagram.header.offset_and_fin = to_varint((offset << 1) + 1);
+        datagram.header.offset_and_fin = (offset << 1) + 1;
       } else {
-        datagram.header.offset_and_fin = to_varint(offset << 1);
+        datagram.header.offset_and_fin = offset << 1;
       }
 
       bytes frag_data(data.begin() + offset,
                       data.begin() + offset + quicr::MAX_TRANSPORT_DATA_SIZE);
 
-      datagram.media_data_length = to_varint(frag_data.size());
+      datagram.media_data_length = frag_data.size();
       datagram.media_data = std::move(frag_data);
 
       msg << datagram;
@@ -385,7 +382,7 @@ QuicRClient::handle_pub_fragment(messages::PublishDatagram&& datagram)
   const auto& msg_iter = fragments[cindex].find(datagram.header.name);
   if (msg_iter != fragments[cindex].end()) {
     // Found
-    msg_iter->second.emplace(from_varint(datagram.header.offset_and_fin),
+    msg_iter->second.emplace(datagram.header.offset_and_fin,
                              std::move(datagram.media_data));
     if (notify_pub_fragment(datagram, msg_iter->second))
       fragments[cindex].erase(msg_iter);
@@ -397,7 +394,7 @@ QuicRClient::handle_pub_fragment(messages::PublishDatagram&& datagram)
       const auto& msg_iter = buf.second.find(datagram.header.name);
       if (msg_iter != buf.second.end()) {
         // Found
-        msg_iter->second.emplace(from_varint(datagram.header.offset_and_fin),
+        msg_iter->second.emplace(datagram.header.offset_and_fin,
                                  std::move(datagram.media_data));
         if (notify_pub_fragment(datagram, msg_iter->second)) {
           fragments[cindex].erase(msg_iter);
@@ -410,8 +407,7 @@ QuicRClient::handle_pub_fragment(messages::PublishDatagram&& datagram)
     if (!found) {
       // If not found in any buffer, then add to current buffer
       fragments[cindex][datagram.header.name].emplace(
-        from_varint(datagram.header.offset_and_fin),
-        std::move(datagram.media_data));
+        datagram.header.offset_and_fin, std::move(datagram.media_data));
     }
   }
 
@@ -441,7 +437,7 @@ QuicRClient::handle(messages::MessageBuffer&& msg)
       messages::SubscribeResponse response;
       msg >> response;
 
-      SubscribeResult result {.status = response.response };
+      SubscribeResult result{ .status = response.response };
 
       if (sub_delegates.count(response.quicr_namespace)) {
         sub_delegates[response.quicr_namespace]->onSubscribeResponse(
@@ -477,7 +473,7 @@ QuicRClient::handle(messages::MessageBuffer&& msg)
       messages::PublishDatagram datagram;
       msg >> datagram;
 
-      if (from_varint(datagram.header.offset_and_fin) == 0x1) {
+      if (datagram.header.offset_and_fin == uintVar_t(0x1)) {
         // No-fragment, process as single object
 
         for (const auto& entry : sub_delegates) {

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -434,7 +434,7 @@ QuicRClient::handle(messages::MessageBuffer&& msg)
     return;
   }
 
-  uint8_t msg_type = msg.back();
+  uint8_t msg_type = msg.front();
 
   switch (msg_type) {
     case static_cast<uint8_t>(messages::MessageType::SubscribeResponse): {

--- a/src/quicr_name.cpp
+++ b/src/quicr_name.cpp
@@ -15,18 +15,6 @@ Name::Name()
 {
 }
 
-Name::Name(const Name& other)
-  : _hi{ other._hi }
-  , _low{ other._low }
-{
-}
-
-Name::Name(Name&& other)
-  : _hi{ std::move(other._hi) }
-  , _low{ std::move(other._low) }
-{
-}
-
 Name::Name(const std::string& hex_value)
 {
   uint8_t start_pos = 0;

--- a/src/quicr_name.cpp
+++ b/src/quicr_name.cpp
@@ -9,12 +9,6 @@
 namespace quicr {
 static constexpr size_t uint_type_bit_size = Name::size() * 4;
 
-Name::Name()
-  : _hi{ 0 }
-  , _low{ 0 }
-{
-}
-
 Name::Name(const std::string& hex_value)
 {
   uint8_t start_pos = 0;
@@ -276,22 +270,6 @@ Name::operator~() const
   name._hi = ~_hi;
   name._low = ~_low;
   return name;
-}
-
-Name&
-Name::operator=(const Name& other)
-{
-  _hi = other._hi;
-  _low = other._low;
-  return *this;
-}
-
-Name&
-Name::operator=(Name&& other)
-{
-  _hi = std::move(other._hi);
-  _low = std::move(other._low);
-  return *this;
 }
 
 bool

--- a/src/quicr_namespace.cpp
+++ b/src/quicr_namespace.cpp
@@ -5,7 +5,7 @@
 
 namespace quicr {
 
-constexpr size_t max_uint_type_bit_size = sizeof(Name::uint_type) * 8 * 2;
+constexpr size_t max_uint_type_bit_size = quicr::Name::size() * 8;
 
 Namespace::Namespace(const Name& name, uint8_t sig_bits)
   : _mask_name{ (name >> (max_uint_type_bit_size - sig_bits))

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -58,7 +58,8 @@ TEST_CASE("SubscribeEnd Message encode/decode")
                   .reason = SubscribeResult::SubscribeStatus::Ok};
 
   MessageBuffer buffer;
-  buffer << s;
+  auto s_copy = s;
+  buffer << std::move(s_copy);
   SubscribeEnd s_out;
   CHECK_NOTHROW((buffer >> s_out));
 
@@ -78,7 +79,8 @@ TEST_CASE("PublishIntent Message encode/decode")
                     { 0, 1, 2, 3, 4 },    uintVar_t{ 0x0100 },
                     uintVar_t{ 0x0000 } };
   MessageBuffer buffer;
-  buffer << pi;
+  auto pi_copy = pi;
+  buffer << std::move(pi_copy);
   PublishIntent pi_out;
   CHECK_NOTHROW((buffer >> pi_out));
 
@@ -117,7 +119,8 @@ TEST_CASE("Publish Message encode/decode")
 
   PublishDatagram p{ d, MediaType::Text, uintVar_t{ 256 }, data };
   MessageBuffer buffer;
-  buffer << p;
+  auto p_copy = p;
+  buffer << std::move(p_copy);
   PublishDatagram p_out;
   CHECK_NOTHROW((buffer >> p_out));
 
@@ -136,7 +139,8 @@ TEST_CASE("PublishStream Message encode/decode")
 {
   PublishStream ps{ uintVar_t{ 5 }, { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
-  buffer << ps;
+  auto ps_copy = ps;
+  buffer << std::move(ps_copy);
   PublishStream ps_out;
   CHECK_NOTHROW((buffer >> ps_out));
 
@@ -146,18 +150,16 @@ TEST_CASE("PublishStream Message encode/decode")
 
 TEST_CASE("PublishIntentEnd Message encode/decode")
 {
-  const std::string name = "12345";
   PublishIntentEnd pie{ MessageType::Publish,
-                        uintVar_t{ 5 },
-                        { name.begin(), name.end() },
+                        {"12345"},
                         { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
-  buffer << pie;
+  auto pie_copy = pie;
+  buffer << std::move(pie_copy);
   PublishIntentEnd pie_out;
   CHECK_NOTHROW((buffer >> pie_out));
 
   CHECK_EQ(pie_out.message_type, pie.message_type);
-  CHECK_EQ(pie_out.name_length, pie.name_length);
   CHECK_EQ(pie_out.name, pie.name);
   CHECK_EQ(pie_out.payload, pie.payload);
 }

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -55,7 +55,7 @@ TEST_CASE("SubscribeEnd Message encode/decode")
   quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
 
   SubscribeEnd s{ .quicr_namespace = qnamespace,
-                  .reason = SubscribeResult::SubscribeStatus::Ok};
+                  .reason = SubscribeResult::SubscribeStatus::Ok };
 
   MessageBuffer buffer;
   auto s_copy = s;
@@ -65,6 +65,20 @@ TEST_CASE("SubscribeEnd Message encode/decode")
 
   CHECK_EQ(s_out.quicr_namespace, s.quicr_namespace);
   CHECK_EQ(s_out.reason, s.reason);
+}
+
+TEST_CASE("Unsubscribe Message encode/decode")
+{
+  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+
+  Unsubscribe us{ .quicr_namespace = qnamespace };
+
+  MessageBuffer buffer;
+  buffer << us;
+  Unsubscribe us_out;
+  CHECK_NOTHROW((buffer >> us_out));
+
+  CHECK_EQ(us_out.quicr_namespace, us.quicr_namespace);
 }
 
 /*===========================================================================*/
@@ -150,9 +164,7 @@ TEST_CASE("PublishStream Message encode/decode")
 
 TEST_CASE("PublishIntentEnd Message encode/decode")
 {
-  PublishIntentEnd pie{ MessageType::Publish,
-                        {"12345"},
-                        { 0, 1, 2, 3, 4 } };
+  PublishIntentEnd pie{ MessageType::Publish, { "12345" }, { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
   auto pie_copy = pie;
   buffer << std::move(pie_copy);
@@ -167,13 +179,14 @@ TEST_CASE("PublishIntentEnd Message encode/decode")
 TEST_CASE("VarInt Encode/Decode")
 {
   MessageBuffer buffer;
-  std::vector<uintVar_t> values = { uintVar_t{128}, uintVar_t{16384}, uintVar_t{536870912} };
-  for (const auto& value : values)
-  {
+  std::vector<uintVar_t> values = { uintVar_t{ 128 },
+                                    uintVar_t{ 16384 },
+                                    uintVar_t{ 536870912 } };
+  for (const auto& value : values) {
     buffer << value;
     uintVar_t out;
     buffer >> out;
 
-    CHECK_NE(out, uintVar_t{0});
+    CHECK_NE(out, uintVar_t{ 0 });
   }
 }

--- a/test/name.cpp
+++ b/test/name.cpp
@@ -1,10 +1,12 @@
 #include <doctest/doctest.h>
-#include <map>
-#include <quicr/quicr_common.h>
 
 #include <quicr/hex_endec.h>
+#include <quicr/quicr_common.h>
 #include <quicr/quicr_name.h>
 #include <quicr/quicr_namespace.h>
+
+#include <map>
+#include <type_traits>
 
 TEST_CASE("quicr::Name Constructor Tests")
 {
@@ -23,6 +25,12 @@ TEST_CASE("quicr::Name Constructor Tests")
 
   CHECK_NOTHROW(quicr::Name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"));
   CHECK_THROWS(quicr::Name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0"));
+
+  CHECK(std::is_trivially_destructible_v<quicr::Name>);
+  CHECK(std::is_trivially_copyable_v<quicr::Name>);
+  CHECK(std::is_trivially_copy_assignable_v<quicr::Name>);
+  CHECK(std::is_trivially_move_constructible_v<quicr::Name>);
+  CHECK(std::is_trivially_move_assignable_v<quicr::Name>);
 }
 
 TEST_CASE("quicr::Name Bit Shifting Tests")
@@ -109,7 +117,7 @@ TEST_CASE("quicr::Name Arithmetic Tests")
   CHECK_EQ(--val42_copy, val42);
 }
 
-TEST_CASE("quicr::Name Constructor Tests")
+TEST_CASE("quicr::Name Bitwise Not Tests")
 {
   quicr::Name zeros;
   quicr::Name ones = ~zeros;

--- a/test/name.cpp
+++ b/test/name.cpp
@@ -100,6 +100,7 @@ TEST_CASE("quicr::Name Arithmetic Tests")
            quicr::Name("0x0000000000000000FFFFFFFFFFFFFFFE"));
 
   quicr::Name val42_copy(val42);
+  CHECK_EQ(val42_copy, val42);
   CHECK_NE(val42_copy++, val43);
   CHECK_EQ(val42_copy, val43);
   CHECK_NE(val42_copy--, val42);
@@ -121,10 +122,10 @@ TEST_CASE("quicr::Name Constructor Tests")
 
 TEST_CASE("quicr::Name Byte Array Tests")
 {
-  std::vector<uint8_t> byte_arr(sizeof(quicr::Name::uint_type) * 2);
-  for (size_t i = 0; i < sizeof(quicr::Name::uint_type); ++i) {
+  std::vector<uint8_t> byte_arr(quicr::Name::size());
+  for (size_t i = 0; i < quicr::Name::size() / 2; ++i) {
     byte_arr[i] = static_cast<uint8_t>((0x0 >> 8 * i));
-    byte_arr[i + sizeof(quicr::Name::uint_type)] =
+    byte_arr[i + quicr::Name::size() / 2] =
       static_cast<uint8_t>((0x1000000000000000 >> 8 * i));
   }
 

--- a/test/quicr_client.cpp
+++ b/test/quicr_client.cpp
@@ -70,9 +70,8 @@ TEST_CASE("Subscribe encode, send and receive")
                      "",
                      {});
 
-  auto fake_transport = std::reinterpret_pointer_cast<FakeTransport>(transport);
   messages::Subscribe s;
-  messages::MessageBuffer msg{ fake_transport->stored_data };
+  messages::MessageBuffer msg{ transport->stored_data };
   msg >> s;
 
   CHECK_EQ(s.transaction_id, s.transaction_id);


### PR DESCRIPTION
Changed the ordering of the message buffer to no longer be backwards, added more move semantics to reduce the cost of writing vectors to the buffer.