### PR TITLE
Catch message buffer exceptions

### DIFF
--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -294,6 +294,7 @@ public:
   void handle(messages::MessageBuffer&& msg);
 
   std::shared_ptr<ITransport> transport;
+  qtransport::LogHandler& log_handler;
 
 private:
   bool notify_pub_fragment(const messages::PublishDatagram& datagram,
@@ -301,7 +302,6 @@ private:
   void handle_pub_fragment(messages::PublishDatagram&& datagram);
 
   qtransport::LogHandler def_log_handler;
-  qtransport::LogHandler& log_handler;
 
   void make_transport(RelayInfo& relay_info, qtransport::LogHandler& logger);
 

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -98,7 +98,14 @@ public:
     }
 
     messages::MessageBuffer msg_buffer{ data.value() };
-    client.handle(std::move(msg_buffer));
+
+    try {
+      client.handle(std::move(msg_buffer));
+    } catch (const std::exception& /* ex */) {
+      // Catches MessageBufferException
+      client.log_handler.log(qtransport::LogLevel::info, "Dropping malformed received message");
+      return;
+    }
   }
 
 private:

--- a/src/quicr_server.cpp
+++ b/src/quicr_server.cpp
@@ -299,23 +299,29 @@ QuicRServer::TransportDelegate::on_recv_notify(
     auto data = server.transport->dequeue(context_id, mStreamId);
 
     if (data.has_value()) {
-      // TODO: Extracting type will change when the message is encoded correctly
-      uint8_t msg_type = data.value().front();
-      messages::MessageBuffer msg_buffer{ data.value() };
+      try {
+        // TODO: Extracting type will change when the message is encoded correctly
+        uint8_t msg_type = data.value().front();
+        messages::MessageBuffer msg_buffer{data.value()};
 
-      switch (static_cast<messages::MessageType>(msg_type)) {
-        case messages::MessageType::Subscribe:
-          server.handle_subscribe(context_id, mStreamId, std::move(msg_buffer));
-          break;
-        case messages::MessageType::Publish:
-          server.handle_publish(context_id, mStreamId, std::move(msg_buffer));
-          break;
-        case messages::MessageType::Unsubscribe:
-          server.handle_unsubscribe(
-            context_id, mStreamId, std::move(msg_buffer));
-          break;
-        default:
-          break;
+        switch (static_cast<messages::MessageType>(msg_type)) {
+          case messages::MessageType::Subscribe:
+            server.handle_subscribe(context_id, mStreamId, std::move(msg_buffer));
+            break;
+          case messages::MessageType::Publish:
+            server.handle_publish(context_id, mStreamId, std::move(msg_buffer));
+            break;
+          case messages::MessageType::Unsubscribe:
+            server.handle_unsubscribe(
+              context_id, mStreamId, std::move(msg_buffer));
+            break;
+          default:
+            break;
+        }
+      } catch (const std::exception& /* ex */) {
+        // catches MessageBufferException
+        // Ignore for now
+        continue;
       }
 
     } else {


### PR DESCRIPTION
Catch message buffer exceptions to prevent aborts on received malformed packets.