### PR TITLE
Some performance stuff and some cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ cmake-build-debug
 
 # vcpkg
 /vcpkg_installed
+
+# Other
+.tmp.dprobes.h

--- a/benchmark/hex_endec.cpp
+++ b/benchmark/hex_endec.cpp
@@ -63,7 +63,7 @@ static void
 BM_HexEndecRealDecode(benchmark::State& state)
 {
   quicr::HexEndec<128, 24, 8, 24, 8, 16, 48> format;
-  quicr::Name name{ "0xA11CEE00F00001000000000000000000" };
+  quicr::Name name = 0xA11CEE00F00001000000000000000000_name;
   for (auto _ : state) {
     format.Decode(name);
   }

--- a/benchmark/message_buffer.cpp
+++ b/benchmark/message_buffer.cpp
@@ -66,7 +66,7 @@ void
 BM_MessageBufferWriteName(benchmark::State& state)
 {
   quicr::messages::MessageBuffer buffer;
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
     buffer << name;
   }

--- a/benchmark/name.cpp
+++ b/benchmark/name.cpp
@@ -6,8 +6,9 @@
 static void
 BM_NameConstructFromHex(benchmark::State& state)
 {
+  std::string str = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
   for (auto _ : state) {
-    [[maybe_unused]] quicr::Name __("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    [[maybe_unused]] quicr::Name __(str);
   }
 }
 
@@ -44,7 +45,7 @@ BM_NameConstructFromBytePointer(benchmark::State& state)
 static void
 BM_NameCopyConstruct(benchmark::State& state)
 {
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
     [[maybe_unused]] quicr::Name __(name);
   }
@@ -53,25 +54,25 @@ BM_NameCopyConstruct(benchmark::State& state)
 static void
 BM_NameLeftShift(benchmark::State& state)
 {
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
-    name <<= 1;
+    name << 64;
   }
 }
 
 static void
 BM_NameRightShift(benchmark::State& state)
 {
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
-    name >>= 1;
+    name >> 64;
   }
 }
 
 static void
 BM_NameAdd(benchmark::State& state)
 {
-  quicr::Name name("0x0");
+  quicr::Name name = 0x0_name;
   for (auto _ : state) {
     ++name;
   }
@@ -80,7 +81,7 @@ BM_NameAdd(benchmark::State& state)
 static void
 BM_NameSub(benchmark::State& state)
 {
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
     --name;
   }
@@ -89,7 +90,7 @@ BM_NameSub(benchmark::State& state)
 static void
 BM_NameToHex(benchmark::State& state)
 {
-  quicr::Name name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name name = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   for (auto _ : state) {
     name.to_hex();
   }
@@ -105,12 +106,12 @@ BENCHMARK(BM_NameAdd);
 BENCHMARK(BM_NameSub);
 BENCHMARK(BM_NameToHex);
 
-const quicr::Name object_id_mask = ~(~quicr::Name() << 16);
-const quicr::Name group_id_mask = ~(~quicr::Name() << 32) << 16;
+constexpr quicr::Name object_id_mask = 0x00000000000000000000000000001111_name;
+constexpr quicr::Name group_id_mask = 0x00000000000000000000111111110000_name;
 static void
 BM_NameRealArithmetic(benchmark::State& state)
 {
-  quicr::Name name{ "0xA11CEE00F00001000000000000000000" };
+  quicr::Name name = 0xA11CEE00F00001000000000000000000_name;
   for (auto _ : state) {
     name = (name & ~object_id_mask) | (++name & object_id_mask);
 

--- a/benchmark/name.cpp
+++ b/benchmark/name.cpp
@@ -4,9 +4,18 @@
 #include <vector>
 
 static void
-BM_NameConstructFromHex(benchmark::State& state)
+BM_NameConstructFromHexString(benchmark::State& state)
 {
   std::string str = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+  for (auto _ : state) {
+    [[maybe_unused]] quicr::Name __(str);
+  }
+}
+
+static void
+BM_NameConstructFromHexStringView(benchmark::State& state)
+{
+  std::string_view str = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
   for (auto _ : state) {
     [[maybe_unused]] quicr::Name __(str);
   }
@@ -96,7 +105,8 @@ BM_NameToHex(benchmark::State& state)
   }
 }
 
-BENCHMARK(BM_NameConstructFromHex);
+BENCHMARK(BM_NameConstructFromHexString);
+BENCHMARK(BM_NameConstructFromHexStringView);
 BENCHMARK(BM_NameConstructFromVector);
 BENCHMARK(BM_NameConstructFromBytePointer);
 BENCHMARK(BM_NameCopyConstruct);

--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -153,7 +153,7 @@ public:
     server->publishIntentResponse(quicr_namespace, result);
   };
 
-  virtual void onPublishIntentEnd(const quicr::Namespace& quicr_namespace,
+  virtual void onPublishIntentEnd(const quicr::Namespace& /* quicr_namespace */,
                                   const std::string& /* auth_token */,
                                   quicr::bytes&& /* e2e_token */)
   {

--- a/cmd/really/reallyTest.cpp
+++ b/cmd/really/reallyTest.cpp
@@ -1,7 +1,7 @@
 
 #include <chrono>
-#include <iostream>
 #include <cstring>
+#include <iostream>
 #include <quicr/quicr_client.h>
 #include <quicr/quicr_common.h>
 #include <sstream>
@@ -9,13 +9,18 @@
 
 #include "testLogger.h"
 
-class subDelegate : public quicr::SubscriberDelegate {
+class subDelegate : public quicr::SubscriberDelegate
+{
 public:
-  subDelegate(testLogger &logger) : logger(logger) {}
+  subDelegate(testLogger& logger)
+    : logger(logger)
+  {
+  }
 
   void onSubscribeResponse(
-    [[ maybe_unused ]] const quicr::Namespace &quicr_namespace,
-    [[ maybe_unused ]] const quicr::SubscribeResult &result) override {
+    [[maybe_unused]] const quicr::Namespace& quicr_namespace,
+    [[maybe_unused]] const quicr::SubscribeResult& result) override
+  {
 
     std::stringstream log_msg;
     log_msg << "onSubscriptionResponse: name: " << quicr_namespace.to_hex()
@@ -23,24 +28,27 @@ public:
             << " status: " << int(static_cast<uint8_t>(result.status));
 
     logger.log(qtransport::LogLevel::info, log_msg.str());
-
   }
 
-  void onSubscriptionEnded([[ maybe_unused ]] const quicr::Namespace &quicr_namespace,
-                           [[ maybe_unused ]] const quicr::SubscribeResult::SubscribeStatus &reason) override {
+  void onSubscriptionEnded(
+    [[maybe_unused]] const quicr::Namespace& quicr_namespace,
+    [[maybe_unused]] const quicr::SubscribeResult::SubscribeStatus& reason)
+    override
+  {
 
     std::stringstream log_msg;
-    log_msg << "onSubscriptionEnded: name: " << quicr_namespace.to_hex()
-            << "/" << int(quicr_namespace.length());
+    log_msg << "onSubscriptionEnded: name: " << quicr_namespace.to_hex() << "/"
+            << int(quicr_namespace.length());
 
     logger.log(qtransport::LogLevel::info, log_msg.str());
   }
 
-  void onSubscribedObject([[ maybe_unused ]] const quicr::Name &quicr_name,
-                          [[ maybe_unused ]] uint8_t priority,
-                          [[ maybe_unused ]] uint16_t expiry_age_ms,
-                          [[ maybe_unused ]] bool use_reliable_transport,
-                          [[ maybe_unused ]] quicr::bytes &&data) override {
+  void onSubscribedObject([[maybe_unused]] const quicr::Name& quicr_name,
+                          [[maybe_unused]] uint8_t priority,
+                          [[maybe_unused]] uint16_t expiry_age_ms,
+                          [[maybe_unused]] bool use_reliable_transport,
+                          [[maybe_unused]] quicr::bytes&& data) override
+  {
     std::stringstream log_msg;
 
     log_msg << "recv object: name: " << quicr_name.to_hex()
@@ -52,30 +60,39 @@ public:
     logger.log(qtransport::LogLevel::info, log_msg.str());
   }
 
-  void onSubscribedObjectFragment([[ maybe_unused ]] const quicr::Name &quicr_name,
-                                  [[ maybe_unused ]] uint8_t priority,
-                                  [[ maybe_unused ]] uint16_t expiry_age_ms,
-                                  [[ maybe_unused ]] bool use_reliable_transport,
-                                  [[ maybe_unused ]] const uint64_t &offset,
-                                  [[ maybe_unused ]] bool is_last_fragment,
-                                  [[ maybe_unused ]] quicr::bytes &&data) override {}
+  void onSubscribedObjectFragment(
+    [[maybe_unused]] const quicr::Name& quicr_name,
+    [[maybe_unused]] uint8_t priority,
+    [[maybe_unused]] uint16_t expiry_age_ms,
+    [[maybe_unused]] bool use_reliable_transport,
+    [[maybe_unused]] const uint64_t& offset,
+    [[maybe_unused]] bool is_last_fragment,
+    [[maybe_unused]] quicr::bytes&& data) override
+  {
+  }
 
 private:
-  testLogger &logger;
+  testLogger& logger;
 };
 
-class pubDelegate : public quicr::PublisherDelegate {
+class pubDelegate : public quicr::PublisherDelegate
+{
 public:
-  void
-  onPublishIntentResponse([[ maybe_unused ]] const quicr::Namespace &quicr_namespace,
-                          [[ maybe_unused ]] const quicr::PublishIntentResult &result) override {}
+  void onPublishIntentResponse(
+    [[maybe_unused]] const quicr::Namespace& quicr_namespace,
+    [[maybe_unused]] const quicr::PublishIntentResult& result) override
+  {
+  }
 };
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char* argv[])
+{
   if ((argc != 2) && (argc != 3)) {
-    std::cerr << "Relay address and port set in RELAY_RELAY and REALLY_PORT env "
-                 "variables."
-              << std::endl;
+    std::cerr
+      << "Relay address and port set in RELAY_RELAY and REALLY_PORT env "
+         "variables."
+      << std::endl;
     std::cerr << std::endl;
     std::cerr << "Usage PUB: reallyTest FF0001 pubData" << std::endl;
     std::cerr << "Usage SUB: reallyTest FF0000" << std::endl;
@@ -84,19 +101,19 @@ int main(int argc, char *argv[]) {
 
   testLogger logger;
 
-  char *relayName = getenv("REALLY_RELAY");
+  char* relayName = getenv("REALLY_RELAY");
   if (!relayName) {
     static char defaultRelay[] = "127.0.0.1";
     relayName = defaultRelay;
   }
 
   int port = 1234;
-  char *portVar = getenv("REALLY_PORT");
+  char* portVar = getenv("REALLY_PORT");
   if (portVar) {
     port = atoi(portVar);
   }
 
-  auto name = quicr::Name(argv[1]);
+  auto name = quicr::Name(std::string(argv[1]));
 
   std::stringstream log_msg;
 
@@ -105,22 +122,21 @@ int main(int argc, char *argv[]) {
 
   std::vector<uint8_t> data;
   if (argc == 3) {
-    data.insert(data.end(), (uint8_t *)(argv[2]),
-                ((uint8_t *)(argv[2])) + strlen(argv[2]));
+    data.insert(
+      data.end(), (uint8_t*)(argv[2]), ((uint8_t*)(argv[2])) + strlen(argv[2]));
   }
 
   log_msg.str("");
   log_msg << "Connecting to " << relayName << ":" << port;
   logger.log(qtransport::LogLevel::info, log_msg.str());
 
-  quicr::RelayInfo relay{.hostname = relayName,
+  quicr::RelayInfo relay{ .hostname = relayName,
                           .port = uint16_t(port),
-                          .proto = quicr::RelayInfo::Protocol::QUIC};
+                          .proto = quicr::RelayInfo::Protocol::QUIC };
 
-  qtransport::TransportConfig tcfg {.tls_cert_filename = NULL,
+  qtransport::TransportConfig tcfg{ .tls_cert_filename = NULL,
                                     .tls_key_filename = NULL };
   quicr::QuicRClient client(relay, tcfg, logger);
-
 
   if (data.size() > 0) {
     // do publish
@@ -141,18 +157,19 @@ int main(int argc, char *argv[]) {
 
     quicr::SubscribeIntent intent = quicr::SubscribeIntent::immediate;
     quicr::bytes empty;
-    client.subscribe(sd, nspace, intent, "origin_url", false, "auth_token",
-                     std::move(empty));
+    client.subscribe(
+      sd, nspace, intent, "origin_url", false, "auth_token", std::move(empty));
 
-    logger.log(qtransport::LogLevel::info, "Sleeping for 20 seconds before unsubscribing");
+    logger.log(qtransport::LogLevel::info,
+               "Sleeping for 20 seconds before unsubscribing");
     std::this_thread::sleep_for(std::chrono::seconds(20));
 
     logger.log(qtransport::LogLevel::info, "Now unsubscribing");
     client.unsubscribe(nspace, {}, {});
 
-    logger.log(qtransport::LogLevel::info, "Sleeping for 15 seconds before exiting");
+    logger.log(qtransport::LogLevel::info,
+               "Sleeping for 15 seconds before exiting");
     std::this_thread::sleep_for(std::chrono::seconds(15));
-
   }
   std::this_thread::sleep_for(std::chrono::seconds(5));
 

--- a/include/quicr/hex_endec.h
+++ b/include/quicr/hex_endec.h
@@ -197,8 +197,7 @@ public:
   template<
     typename Uint_t = uint64_t,
     typename = typename std::enable_if<is_valid_uint<Uint_t>::value, Uint_t>>
-  static constexpr std::array<Uint_t, sizeof...(Dist)> Decode(
-    std::string_view hex)
+  static inline std::array<Uint_t, sizeof...(Dist)> Decode(std::string_view hex)
   {
     static_assert((Size & (Size - 1)) == 0, "Size must be a power of 2");
     static_assert(Size >= (Dist + ...),
@@ -216,7 +215,7 @@ public:
   template<
     typename Uint_t = uint64_t,
     typename = typename std::enable_if<is_valid_uint<Uint_t>::value, Uint_t>>
-  static constexpr std::array<Uint_t, sizeof...(Dist)> Decode(
+  static inline std::array<Uint_t, sizeof...(Dist)> Decode(
     const quicr::Name& name)
   {
     static_assert((Size & (Size - 1)) == 0, "Size must be a power of 2");
@@ -236,7 +235,7 @@ public:
     typename Uint_t = uint64_t,
     bool B = Size <= sizeof(uint64_t) * 8,
     typename = typename std::enable_if<is_valid_uint<Uint_t>::value, Uint_t>>
-  static constexpr typename std::enable_if<B, std::vector<Uint_t>>::type Decode(
+  static inline typename std::enable_if<B, std::vector<Uint_t>>::type Decode(
     std::span<uint8_t> distribution,
     std::string_view hex)
   {
@@ -258,8 +257,9 @@ public:
     typename Uint_t = uint64_t,
     bool B = Size <= sizeof(uint64_t) * 8,
     typename = typename std::enable_if<is_valid_uint<Uint_t>::value, Uint_t>>
-  static constexpr typename std::enable_if<!B, std::vector<Uint_t>>::type
-  Decode(std::span<uint8_t> distribution, std::string_view hex)
+  static inline typename std::enable_if<!B, std::vector<Uint_t>>::type Decode(
+    std::span<uint8_t> distribution,
+    std::string_view hex)
   {
     static_assert((Size & (Size - 1)) == 0, "Size must be a power of 2");
 
@@ -297,8 +297,8 @@ public:
   }
 
   template<typename Uint_t = uint64_t>
-  static constexpr std::vector<Uint_t> Decode(std::span<uint8_t> distribution,
-                                              const quicr::Name& name)
+  static inline std::vector<Uint_t> Decode(std::span<uint8_t> distribution,
+                                           const quicr::Name& name)
   {
     return Decode(distribution, std::string_view(name.to_hex()));
   }

--- a/include/quicr/quicr_name.h
+++ b/include/quicr/quicr_name.h
@@ -115,7 +115,7 @@ public:
     }
   }
 
-  constexpr Name(const std::string& hex)
+  Name(const std::string& hex)
     : Name(std::string_view(hex))
   {
   }

--- a/include/quicr/quicr_name.h
+++ b/include/quicr/quicr_name.h
@@ -56,7 +56,7 @@ hex_to_uint(std::string_view x)
 
 template<typename T,
          typename = typename std::enable_if<std::is_unsigned_v<T>, T>::type>
-constexpr std::string
+std::string
 uint_to_hex(T y)
 {
   char x[sizeof(T) * 2 + 1] = "";

--- a/include/quicr/quicr_name.h
+++ b/include/quicr/quicr_name.h
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace quicr {
@@ -11,6 +12,40 @@ namespace messages {
 class MessageBuffer;
 }
 
+/**
+ * Compile-time hex string to unsigned integer conversion.
+ */
+constexpr uint64_t
+hex_to_uint(const std::string_view& x)
+{
+  size_t start_pos = x.substr(0, 2) == "0x" ? 2 : 0;
+
+  uint64_t y = 0;
+  for (size_t i = start_pos; i < x.length(); ++i) {
+    y *= 16ull;
+    if ('0' <= x[i] && x[i] <= '9')
+      y += x[i] - '0';
+    else if ('A' <= x[i] && x[i] <= 'F')
+      y += x[i] - 'A' + 10;
+    else if ('a' <= x[i] && x[i] <= 'f')
+      y += x[i] - 'a' + 10;
+  }
+
+  return y;
+}
+
+/**
+ * Name specific exception, thrown only on creation of name where string
+ * byte count is too long.
+ */
+struct NameException : public std::runtime_error
+{
+  using std::runtime_error::runtime_error;
+};
+
+/**
+ * @brief Name class used for passing data in bits.
+ */
 class Name
 {
   using uint_type = uint64_t;
@@ -19,10 +54,28 @@ public:
   constexpr Name() = default;
   constexpr Name(const Name& other) = default;
   Name(Name&& other) = default;
-  Name(const std::string& hex_value);
+  Name(const std::string& x);
   Name(uint8_t* data, size_t length);
   Name(const uint8_t* data, size_t length);
   Name(const std::vector<uint8_t>& data);
+  constexpr Name(const std::string_view& x)
+  {
+    size_t start_pos = (x.substr(0, 2) == "0x") * 2;
+    auto hex_value = x.substr(start_pos, x.length() - start_pos);
+
+    if (hex_value.length() > size() * 2)
+      throw NameException("Hex string cannot be longer than " +
+                          std::to_string(size() * 2) + " bytes");
+
+    if (hex_value.length() > size()) {
+      _hi = hex_to_uint(hex_value.substr(0, hex_value.length() - size()));
+      _low = hex_to_uint(hex_value.substr(hex_value.length() - size(), size()));
+    } else {
+      _hi = 0;
+      _low = hex_to_uint(x.substr(0, x.length()));
+    }
+  }
+
   ~Name() = default;
 
   std::string to_hex() const;
@@ -68,8 +121,9 @@ private:
   uint_type _low{ 0 };
 };
 
-struct NameException : public std::runtime_error
+}
+
+constexpr quicr::Name operator""_name(const char* x)
 {
-  using std::runtime_error::runtime_error;
-};
+  return { std::string_view(x) };
 }

--- a/include/quicr/quicr_namespace.h
+++ b/include/quicr/quicr_namespace.h
@@ -2,11 +2,13 @@
 
 #include <quicr/quicr_name.h>
 
-namespace quicr {
-namespace messages {
-class MessageBuffer;
-}
+#include <ostream>
 
+namespace quicr {
+
+/**
+ * @brief A prefix for a quicr::Name
+ */
 class Namespace
 {
 public:
@@ -20,20 +22,27 @@ public:
   Namespace& operator=(Namespace&& other) = default;
 
   bool contains(const Name& name) const;
-  bool contains(const Namespace& name_space) const;
-  constexpr Name name() const { return _mask_name; }
+  bool contains(const Namespace& prefix) const { return contains(prefix._name); }
+
+  constexpr Name name() const { return _name; }
   constexpr uint8_t length() const { return _sig_bits; }
   std::string to_hex() const;
 
   friend bool operator==(const Namespace& a, const Namespace& b);
   friend bool operator!=(const Namespace& a, const Namespace& b);
+
   friend bool operator>(const Namespace& a, const Namespace& b);
+  friend bool operator>(const Namespace& a, const Name& b);
+  friend bool operator>(const Name& a, const Namespace& b);
+
   friend bool operator<(const Namespace& a, const Namespace& b);
+  friend bool operator<(const Namespace& a, const Name& b);
+  friend bool operator<(const Name& a, const Namespace& b);
 
   friend std::ostream& operator<<(std::ostream& os, const Namespace& ns);
 
 private:
-  Name _mask_name;
+  Name _name;
   uint8_t _sig_bits;
 };
 }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -353,7 +353,7 @@ messages::MessageBuffer&
 operator<<(messages::MessageBuffer& msg, const quicr::Name& val)
 {
   constexpr uint8_t size = quicr::Name::size();
-  for (size_t i = 0; i < size; ++i)
+  for (int i = size - 1; i >= 0; --i)
     msg << val[i];
 
   return msg;
@@ -364,7 +364,7 @@ operator>>(messages::MessageBuffer& msg, quicr::Name& val)
 {
   constexpr uint8_t size = quicr::Name::size();
   std::array<uint8_t, size> bytes;
-  for (int i = 0; i < size; ++i)
+  for (int i = size - 1; i >= 0; --i)
     msg >> bytes[i];
 
   val = Name{ bytes.data(), size };

--- a/src/quicr_name.cpp
+++ b/src/quicr_name.cpp
@@ -9,32 +9,27 @@
 namespace quicr {
 static constexpr size_t uint_type_bit_size = Name::size() * 4;
 
-Name::Name(const std::string& hex_value)
+Name::Name(const std::string& x)
 {
-  uint8_t start_pos = 0;
-  if (hex_value.substr(0, 2) == "0x")
-    start_pos = 2;
+  size_t start_pos = (x.substr(0, 2) == "0x") * 2;
+  auto hex_value = x.substr(start_pos, x.length() - start_pos);
 
-  if (hex_value.length() - start_pos > size() * 2)
+  if (hex_value.length() > size() * 2)
     throw NameException("Hex string cannot be longer than " +
                         std::to_string(size() * 2) + " bytes");
 
-  if (hex_value.length() - start_pos > size()) {
-    _hi = std::stoull(
-      hex_value.substr(start_pos, hex_value.length() - start_pos - size()),
-      nullptr,
-      16);
-    _low = std::stoull(
-      hex_value.substr(hex_value.length() - size(), size()), nullptr, 16);
+  if (hex_value.length() > size()) {
+    _hi = hex_to_uint(hex_value.substr(0, hex_value.length() - size()));
+    _low = hex_to_uint(hex_value.substr(hex_value.length() - size(), size()));
   } else {
     _hi = 0;
-    _low = std::stoull(hex_value, nullptr, 16);
+    _low = hex_to_uint(x.substr(0, x.length()));
   }
 }
 
 Name::Name(uint8_t* data, [[maybe_unused]] size_t length)
 {
-  assert(length == size());
+  assert(length == size() * 2);
 
   constexpr size_t size_of = size() / 2;
   std::memcpy(&_low, data, size_of);
@@ -43,7 +38,7 @@ Name::Name(uint8_t* data, [[maybe_unused]] size_t length)
 
 Name::Name(const uint8_t* data, [[maybe_unused]] size_t length)
 {
-  assert(length == size());
+  assert(length == size() * 2);
 
   constexpr size_t size_of = size() / 2;
   std::memcpy(&_low, data, size_of);

--- a/src/quicr_name.cpp
+++ b/src/quicr_name.cpp
@@ -9,7 +9,12 @@
 namespace quicr {
 Name::Name(uint8_t* data, size_t length)
 {
-  size_t size_of = std::min(length, size() / 2);
+  if (length > size() * 2)
+    throw NameException(
+      "Byte array length cannot be longer than length of Name: " +
+      std::to_string(size() * 2));
+
+  constexpr size_t size_of = size() / 2;
   std::memcpy(&_low, data, size_of);
   std::memcpy(&_hi, data + size_of, size_of);
 }
@@ -17,16 +22,23 @@ Name::Name(uint8_t* data, size_t length)
 Name::Name(const uint8_t* data, size_t length)
 {
   if (length > size() * 2)
-    throw NameException("");
+    throw NameException(
+      "Byte array length cannot be longer than length of Name: " +
+      std::to_string(size() * 2));
 
-  size_t size_of = std::min(length, size() / 2);
+  constexpr size_t size_of = size() / 2;
   std::memcpy(&_low, data, size_of);
   std::memcpy(&_hi, data + size_of, size_of);
 }
 
 Name::Name(const std::vector<uint8_t>& data)
 {
-  size_t size_of = std::min(data.size(), size() / 2);
+  if (data.size() > size() * 2)
+    throw NameException(
+      "Byte array length cannot be longer than length of Name: " +
+      std::to_string(size() * 2));
+
+  constexpr size_t size_of = size() / 2;
   std::memcpy(&_low, data.data(), size_of);
   std::memcpy(&_hi, data.data() + size_of, size_of);
 }

--- a/src/quicr_namespace.cpp
+++ b/src/quicr_namespace.cpp
@@ -1,22 +1,15 @@
-#include <quicr/message_buffer.h>
 #include <quicr/quicr_namespace.h>
-
-#include <sstream>
 
 namespace quicr {
 
-constexpr size_t max_uint_type_bit_size = quicr::Name::size() * 8;
-
 Namespace::Namespace(const Name& name, uint8_t sig_bits)
-  : _mask_name{ (name >> (max_uint_type_bit_size - sig_bits))
-                << (max_uint_type_bit_size - sig_bits) }
+  : _name{ name & ~(~0x0_name >> sig_bits) }
   , _sig_bits{ sig_bits }
 {
 }
 
 Namespace::Namespace(Name&& name, uint8_t sig_bits)
-  : _mask_name{ std::move(name >> (max_uint_type_bit_size - sig_bits))
-                << (max_uint_type_bit_size - sig_bits) }
+  : _name{ name & ~(~0x0_name >> sig_bits) }
   , _sig_bits{ sig_bits }
 {
 }
@@ -24,26 +17,19 @@ Namespace::Namespace(Name&& name, uint8_t sig_bits)
 bool
 Namespace::contains(const Name& name) const
 {
-  const uint8_t insig_bits = max_uint_type_bit_size - _sig_bits;
-  return (name >> insig_bits) == (_mask_name >> insig_bits);
-}
-
-bool
-Namespace::contains(const Namespace& name_space) const
-{
-  return contains(name_space._mask_name);
+  return (name & ~(~0x0_name >> _sig_bits)) == _name;
 }
 
 std::string
 Namespace::to_hex() const
 {
-  return _mask_name.to_hex();
+  return _name.to_hex();
 }
 
 bool
 operator==(const Namespace& a, const Namespace& b)
 {
-  return a._mask_name == b._mask_name && a._sig_bits == b._sig_bits;
+  return a._name == b._name && a._sig_bits == b._sig_bits;
 }
 
 bool
@@ -55,13 +41,37 @@ operator!=(const Namespace& a, const Namespace& b)
 bool
 operator>(const Namespace& a, const Namespace& b)
 {
-  return a._mask_name > b._mask_name;
+  return a._name > b._name;
+}
+
+bool
+operator>(const Namespace& a, const Name& b)
+{
+  return a._name > b;
+}
+
+bool
+operator>(const Name& a, const Namespace& b)
+{
+  return a > b._name;
 }
 
 bool
 operator<(const Namespace& a, const Namespace& b)
 {
-  return a._mask_name < b._mask_name;
+  return a._name < b._name;
+}
+
+bool
+operator<(const Namespace& a, const Name& b)
+{
+  return a._name < b;
+}
+
+bool
+operator<(const Name& a, const Namespace& b)
+{
+  return a < b._name;
 }
 
 std::ostream&

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_executable(quicr_test
                 main.cpp
                 name.cpp
+                namespace.cpp
                 quicr_client.cpp
                 quicr_server.cpp
                 encode.cpp

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -21,7 +21,7 @@ TEST_CASE("MessageBuffer Decode Exception")
 
 TEST_CASE("Subscribe Message encode/decode")
 {
-  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
 
   Subscribe s{ 1, 0x1000, qnamespace, SubscribeIntent::immediate };
   MessageBuffer buffer;
@@ -36,7 +36,7 @@ TEST_CASE("Subscribe Message encode/decode")
 
 TEST_CASE("SubscribeResponse Message encode/decode")
 {
-  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
 
   SubscribeResponse s{ qnamespace,
                        SubscribeResult::SubscribeStatus::Ok,
@@ -52,7 +52,7 @@ TEST_CASE("SubscribeResponse Message encode/decode")
 
 TEST_CASE("SubscribeEnd Message encode/decode")
 {
-  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
 
   SubscribeEnd s{ .quicr_namespace = qnamespace,
                   .reason = SubscribeResult::SubscribeStatus::Ok };
@@ -69,7 +69,7 @@ TEST_CASE("SubscribeEnd Message encode/decode")
 
 TEST_CASE("Unsubscribe Message encode/decode")
 {
-  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
 
   Unsubscribe us{ .quicr_namespace = qnamespace };
 
@@ -87,7 +87,7 @@ TEST_CASE("Unsubscribe Message encode/decode")
 
 TEST_CASE("PublishIntent Message encode/decode")
 {
-  quicr::Namespace qnamespace{ { "0x10000000000000002000" }, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
   PublishIntent pi{ MessageType::Publish, 0x1000,
                     qnamespace,           { 0, 1, 2, 3, 4 },
                     uintVar_t{ 0x0100 },  uintVar_t{ 0x0000 } };
@@ -120,7 +120,7 @@ TEST_CASE("PublishIntentResponse Message encode/decode")
 
 TEST_CASE("Publish Message encode/decode")
 {
-  quicr::Name qn{ "0x10000000000000002000" };
+  quicr::Name qn = 0x10000000000000002000_name;
   Header d{ uintVar_t{ 0x1000 }, qn,
             uintVar_t{ 0x0100 }, uintVar_t{ 0x0010 },
             uintVar_t{ 0x0001 }, 0x0000 };
@@ -163,7 +163,7 @@ TEST_CASE("PublishStream Message encode/decode")
 TEST_CASE("PublishIntentEnd Message encode/decode")
 {
   PublishIntentEnd pie{ MessageType::Publish,
-                        { { "12345" }, 0u },
+                        { 12345_name, 0u },
                         { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
   auto pie_copy = pie;

--- a/test/hex_endec.cpp
+++ b/test/hex_endec.cpp
@@ -17,7 +17,8 @@ TEST_CASE("quicr::HexEndec 256bit Encode/Decode Test")
     first_part, second_part, third_part, fourth_part, last_part);
   CHECK_EQ(mask, hex_value);
 
-  const auto [one, two, three, four, last] = formatter_256bit.Decode(hex_value);
+  const auto [one, two, three, four, last] =
+    formatter_256bit.Decode(std::string_view(hex_value));
   CHECK_EQ(one, first_part);
   CHECK_EQ(two, second_part);
   CHECK_EQ(three, third_part);
@@ -37,7 +38,8 @@ TEST_CASE("quicr::HexEndec 128bit Encode/Decode Test")
     formatter_128bit.Encode(first_part, second_part, third_part);
   CHECK_EQ(mask, hex_value);
 
-  const auto [one, two, three] = formatter_128bit.Decode(hex_value);
+  const auto [one, two, three] =
+    formatter_128bit.Decode(std::string_view(hex_value));
   CHECK_EQ(one, first_part);
   CHECK_EQ(two, second_part);
   CHECK_EQ(three, third_part);
@@ -45,7 +47,7 @@ TEST_CASE("quicr::HexEndec 128bit Encode/Decode Test")
 
 TEST_CASE("quicr::HexEndec 128bit Encode/Decode Container Test")
 {
-  const std::string hex_value = "0x11111111111111112222222222222200";
+  const std::string_view hex_value = "0x11111111111111112222222222222200";
   const uint64_t first_part = 0x1111111111111111ull;
   const uint64_t second_part = 0x22222222222222ull;
   const uint8_t third_part = 0x00ull;
@@ -63,7 +65,7 @@ TEST_CASE("quicr::HexEndec 128bit Encode/Decode Container Test")
 
 TEST_CASE("quicr::HexEndec 64bit Encode/Decode Test")
 {
-  const std::string hex_value = "0x1111111122222200";
+  const std::string_view hex_value = "0x1111111122222200";
   const uint64_t first_part = 0x11111111ull;
   const uint64_t second_part = 0x222222ull;
   const uint8_t third_part = 0x00ull;
@@ -81,9 +83,9 @@ TEST_CASE("quicr::HexEndec 64bit Encode/Decode Test")
 
 TEST_CASE("quicr::HexEndec Decode Throw Test")
 {
-  const std::string valid_hex_value = "0x11111111111111112222222222222200";
-  const std::string invalid_hex_value = "0x111111111111111122222222222222";
-  const std::string another_invalid_hex_value =
+  const std::string_view valid_hex_value = "0x11111111111111112222222222222200";
+  const std::string_view invalid_hex_value = "0x111111111111111122222222222222";
+  const std::string_view another_invalid_hex_value =
     "0x1111111111111111222222222222220000";
 
   quicr::HexEndec<128, 64, 56, 8> formatter_128bit;

--- a/test/name.cpp
+++ b/test/name.cpp
@@ -10,21 +10,19 @@
 
 TEST_CASE("quicr::Name Constructor Tests")
 {
-  quicr::Name val42("0x42");
-  quicr::Name hex42("0x42");
+  constexpr quicr::Name val42(0x42_name);
+  constexpr quicr::Name hex42(0x42_name);
   CHECK_EQ(val42, hex42);
 
-  CHECK_LT(quicr::Name("0x123"), quicr::Name("0x124"));
-  CHECK_GT(quicr::Name("0x123"), quicr::Name("0x122"));
-  CHECK_NE(quicr::Name("0x123"), quicr::Name("0x122"));
+  CHECK_LT(0x123_name, 0x124_name);
+  CHECK_GT(0x123_name, 0x122_name);
+  CHECK_NE(0x123_name, 0x122_name);
 
-  CHECK_GT(quicr::Name("0x20000000000000001"),
-           quicr::Name("0x10000000000000002"));
-  CHECK_LT(quicr::Name("0x10000000000000002"),
-           quicr::Name("0x20000000000000001"));
+  CHECK_GT(0x20000000000000001_name, 0x10000000000000002_name);
+  CHECK_LT(0x10000000000000002_name, 0x20000000000000001_name);
 
-  CHECK_NOTHROW(quicr::Name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"));
-  CHECK_THROWS(quicr::Name("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0"));
+  CHECK_NOTHROW(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name);
+  CHECK_THROWS(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0_name);
 
   CHECK(std::is_trivially_destructible_v<quicr::Name>);
   CHECK(std::is_trivially_copyable_v<quicr::Name>);
@@ -42,22 +40,22 @@ TEST_CASE("quicr::Name Constructor Tests")
 TEST_CASE("quicr::Name To Hex Tests")
 {
   {
-    std::string original_hex = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    std::string_view original_hex = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
     quicr::Name name = original_hex;
 
     CHECK_EQ(name.to_hex(), original_hex);
   }
   {
-    std::string original_hex = "0xFFFFFFFFFFFFFFFF0000000000000000";
+    std::string_view original_hex = "0xFFFFFFFFFFFFFFFF0000000000000000";
     quicr::Name name = original_hex;
 
     CHECK_EQ(name.to_hex(), original_hex);
   }
   {
-    std::string long_hex = "0x0000000000000000FFFFFFFFFFFFFFFF";
+    std::string_view long_hex = "0x0000000000000000FFFFFFFFFFFFFFFF";
     quicr::Name long_name = long_hex;
 
-    std::string short_hex = "0xFFFFFFFFFFFFFFFF";
+    std::string_view short_hex = "0xFFFFFFFFFFFFFFFF";
     quicr::Name not_short_name = short_hex;
     CHECK_EQ(long_name.to_hex(), long_hex);
     CHECK_NE(not_short_name.to_hex(), short_hex);
@@ -68,45 +66,41 @@ TEST_CASE("quicr::Name To Hex Tests")
 
 TEST_CASE("quicr::Name Bit Shifting Tests")
 {
-  CHECK_EQ((quicr::Name("0x1234") >> 4), quicr::Name("0x123"));
-  CHECK_EQ((quicr::Name("0x1234") << 4), quicr::Name("0x12340"));
+  CHECK_EQ((0x1234_name >> 4), 0x123_name);
+  CHECK_EQ((0x1234_name << 4), 0x12340_name);
 
   {
-    const quicr::Name unshifted_32bit("0x123456789abcdeff00000000");
-    const quicr::Name shifted_32bit("0x123456789abcdeff");
+    const quicr::Name unshifted_32bit = 0x123456789abcdeff00000000_name;
+    const quicr::Name shifted_32bit = 0x123456789abcdeff_name;
     CHECK_EQ((unshifted_32bit >> 32), shifted_32bit);
     CHECK_EQ((shifted_32bit << 32), unshifted_32bit);
   }
 
   {
-    quicr::Name unshifted_64bit =
-      quicr::Name("0x123456789abcdeff123456789abcdeff");
-    quicr::Name shifted_64bit = quicr::Name("0x123456789abcdeff");
-    quicr::Name shifted_72bit = quicr::Name("0x123456789abcde");
+    quicr::Name unshifted_64bit = 0x123456789abcdeff123456789abcdeff_name;
+    quicr::Name shifted_64bit = 0x123456789abcdeff_name;
+    quicr::Name shifted_72bit = 0x123456789abcde_name;
     CHECK_EQ((unshifted_64bit >> 64), shifted_64bit);
     CHECK_EQ((unshifted_64bit >> 72), shifted_72bit);
     CHECK_EQ((shifted_64bit >> 8), shifted_72bit);
   }
 
   {
-    quicr::Name unshifted_64bit = quicr::Name("0x123456789abcdeff");
-    quicr::Name shifted_64bit =
-      quicr::Name("0x123456789abcdeff0000000000000000");
-    quicr::Name shifted_72bit =
-      quicr::Name("0x3456789abcdeff000000000000000000");
+    quicr::Name unshifted_64bit = 0x123456789abcdeff_name;
+    quicr::Name shifted_64bit = 0x123456789abcdeff0000000000000000_name;
+    quicr::Name shifted_72bit = 0x3456789abcdeff000000000000000000_name;
     CHECK_EQ((unshifted_64bit << 64), shifted_64bit);
     CHECK_EQ((unshifted_64bit << 72), shifted_72bit);
     CHECK_EQ((shifted_64bit << 8), shifted_72bit);
   }
 
   {
-    const quicr::Name unshifted_bits =
-      quicr::Name("0x00000000000000000000000000000001");
+    const quicr::Name unshifted_bits = 0x00000000000000000000000000000001_name;
     quicr::Name bits = unshifted_bits;
     for (int i = 0; i < 64; ++i)
       bits <<= 1;
 
-    CHECK_EQ(bits, quicr::Name("0x00000000000000010000000000000000"));
+    CHECK_EQ(bits, 0x00000000000000010000000000000000_name);
 
     for (int i = 0; i < 64; ++i)
       bits >>= 1;
@@ -117,28 +111,27 @@ TEST_CASE("quicr::Name Bit Shifting Tests")
 
 TEST_CASE("quicr::Name Arithmetic Tests")
 {
-  quicr::Name val42("0x42");
-  quicr::Name val41("0x41");
-  quicr::Name val43("0x43");
+  quicr::Name val42 = 0x42_name;
+  quicr::Name val41 = 0x41_name;
+  quicr::Name val43 = 0x43_name;
   CHECK_EQ(val42 + 1, val43);
   CHECK_EQ(val42 - 1, val41);
 
-  CHECK_EQ(quicr::Name("0x00000000000000010000000000000000") + 1,
-           quicr::Name("0x00000000000000010000000000000001"));
-  CHECK_EQ(quicr::Name("0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") + 1,
-           quicr::Name("0x10000000000000000000000000000000"));
-  CHECK_EQ(quicr::Name("0x0000000000000000FFFFFFFFFFFFFFFF") + 0xFFFFFFFF,
-           quicr::Name("0x000000000000000100000000FFFFFFFE"));
+  CHECK_EQ(0x00000000000000010000000000000000_name + 1,
+           0x00000000000000010000000000000001_name);
+  CHECK_EQ(0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name + 1,
+           0x10000000000000000000000000000000_name);
+  CHECK_EQ(0x0000000000000000FFFFFFFFFFFFFFFF_name + 0xFFFFFFFF,
+           0x000000000000000100000000FFFFFFFE_name);
 
-  CHECK_EQ(quicr::Name("0x00000000000000010000000000000000") - 1,
-           quicr::Name("0x0000000000000000FFFFFFFFFFFFFFFF"));
-  CHECK_EQ(quicr::Name("0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") - 1,
-           quicr::Name("0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE"));
-  CHECK_EQ(quicr::Name("0x0000000000000000FFFFFFFFFFFFFFFF") -
-             0xFFFFFFFFFFFFFFFF,
-           quicr::Name("0x00000000000000000000000000000000"));
-  CHECK_EQ(quicr::Name("0x00000000000000010000000000000000") - 2,
-           quicr::Name("0x0000000000000000FFFFFFFFFFFFFFFE"));
+  CHECK_EQ(0x00000000000000010000000000000000_name - 1,
+           0x0000000000000000FFFFFFFFFFFFFFFF_name);
+  CHECK_EQ(0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name - 1,
+           0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE_name);
+  CHECK_EQ(0x0000000000000000FFFFFFFFFFFFFFFF_name - 0xFFFFFFFFFFFFFFFF,
+           0x00000000000000000000000000000000_name);
+  CHECK_EQ(0x00000000000000010000000000000000_name - 2,
+           0x0000000000000000FFFFFFFFFFFFFFFE_name);
 
   quicr::Name val42_copy(val42);
   CHECK_EQ(val42_copy, val42);
@@ -155,10 +148,12 @@ TEST_CASE("quicr::Name Bitwise Not Tests")
   quicr::Name zeros;
   quicr::Name ones = ~zeros;
 
-  quicr::Name expected_ones("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+  quicr::Name expected_ones = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
+  auto literal_ones = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
 
   CHECK_NE(ones, zeros);
   CHECK_EQ(ones, expected_ones);
+  CHECK_EQ(literal_ones, expected_ones);
 }
 
 TEST_CASE("quicr::Name Byte Array Tests")
@@ -173,7 +168,7 @@ TEST_CASE("quicr::Name Byte Array Tests")
   CHECK_FALSE(byte_arr.empty());
   CHECK_EQ(byte_arr.size(), 16);
 
-  quicr::Name name_to_bytes("0x10000000000000000000000000000000");
+  quicr::Name name_to_bytes = 0x10000000000000000000000000000000_name;
   quicr::Name name_from_bytes(byte_arr);
   CHECK_EQ(name_from_bytes, name_to_bytes);
 
@@ -183,19 +178,19 @@ TEST_CASE("quicr::Name Byte Array Tests")
 
 TEST_CASE("quicr::Name Logical Arithmetic Tests")
 {
-  auto arith_and = quicr::Name("0x01010101010101010101010101010101") &
-                   quicr::Name("0x10101010101010101010101010101010");
-  CHECK_EQ(arith_and, quicr::Name("0x0"));
+  auto arith_and = 0x01010101010101010101010101010101_name &
+                   0x10101010101010101010101010101010_name;
+  CHECK_EQ(arith_and, 0x0_name);
 
-  auto arith_and2 = quicr::Name("0x0101010101010101") & 0x1010101010101010;
-  CHECK_EQ(arith_and2, quicr::Name("0x0"));
+  auto arith_and2 = 0x0101010101010101_name & 0x1010101010101010;
+  CHECK_EQ(arith_and2, 0x0_name);
 
-  auto arith_or = quicr::Name("0x01010101010101010101010101010101") |
-                  quicr::Name("0x10101010101010101010101010101010");
-  CHECK_EQ(arith_or, quicr::Name("0x11111111111111111111111111111111"));
+  auto arith_or = 0x01010101010101010101010101010101_name |
+                  0x10101010101010101010101010101010_name;
+  CHECK_EQ(arith_or, 0x11111111111111111111111111111111_name);
 
-  auto arith_or2 = quicr::Name("0x0101010101010101") | 0x1010101010101010;
-  CHECK_EQ(arith_or2, quicr::Name("0x1111111111111111"));
+  auto arith_or2 = 0x0101010101010101_name | 0x1010101010101010;
+  CHECK_EQ(arith_or2, 0x1111111111111111_name);
 }
 
 TEST_CASE("quicr::Namespace Contains Names Test")
@@ -220,13 +215,13 @@ TEST_CASE("quicr::Namespace Contains Names Test")
 
 TEST_CASE("quicr::Namespace Contains Namespaces Test")
 {
-  quicr::Namespace ns({ "0x11111111111111112222222222220000" }, 112);
+  quicr::Namespace ns(0x11111111111111112222222222220000_name, 112);
 
-  quicr::Namespace valid_namespace({ "0x11111111111111112222222222222200" },
+  quicr::Namespace valid_namespace(0x11111111111111112222222222222200_name,
                                    120);
   CHECK(ns.contains(valid_namespace));
 
-  quicr::Namespace invalid_namespace({ "0x11111111111111112222222222000000" },
+  quicr::Namespace invalid_namespace(0x11111111111111112222222222000000_name,
                                      104);
   CHECK_FALSE(ns.contains(invalid_namespace));
 }

--- a/test/name.cpp
+++ b/test/name.cpp
@@ -1,11 +1,7 @@
 #include <doctest/doctest.h>
 
-#include <quicr/hex_endec.h>
-#include <quicr/quicr_common.h>
 #include <quicr/quicr_name.h>
-#include <quicr/quicr_namespace.h>
 
-#include <map>
 #include <type_traits>
 
 TEST_CASE("quicr::Name Constructor Tests")
@@ -24,17 +20,14 @@ TEST_CASE("quicr::Name Constructor Tests")
   CHECK_NOTHROW(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name);
   CHECK_THROWS(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0_name);
 
+  CHECK(std::is_trivial_v<quicr::Name>);
+  CHECK(std::is_trivially_constructible_v<quicr::Name>);
+  CHECK(std::is_trivially_default_constructible_v<quicr::Name>);
   CHECK(std::is_trivially_destructible_v<quicr::Name>);
   CHECK(std::is_trivially_copyable_v<quicr::Name>);
   CHECK(std::is_trivially_copy_assignable_v<quicr::Name>);
   CHECK(std::is_trivially_move_constructible_v<quicr::Name>);
   CHECK(std::is_trivially_move_assignable_v<quicr::Name>);
-
-  CHECK(std::is_trivially_destructible_v<quicr::Namespace>);
-  CHECK(std::is_trivially_copyable_v<quicr::Namespace>);
-  CHECK(std::is_trivially_copy_assignable_v<quicr::Namespace>);
-  CHECK(std::is_trivially_move_constructible_v<quicr::Namespace>);
-  CHECK(std::is_trivially_move_assignable_v<quicr::Namespace>);
 }
 
 TEST_CASE("quicr::Name To Hex Tests")
@@ -145,8 +138,8 @@ TEST_CASE("quicr::Name Arithmetic Tests")
 
 TEST_CASE("quicr::Name Bitwise Not Tests")
 {
-  quicr::Name zeros;
-  quicr::Name ones = ~zeros;
+  constexpr quicr::Name zeros = 0x0_name;
+  constexpr quicr::Name ones = ~zeros;
 
   quicr::Name expected_ones = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
   auto literal_ones = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
@@ -191,37 +184,4 @@ TEST_CASE("quicr::Name Logical Arithmetic Tests")
 
   auto arith_or2 = 0x0101010101010101_name | 0x1010101010101010;
   CHECK_EQ(arith_or2, 0x1111111111111111_name);
-}
-
-TEST_CASE("quicr::Namespace Contains Names Test")
-{
-  quicr::HexEndec<128, 64, 56, 8> formatter_128bit;
-  std::string mask = formatter_128bit.Encode(
-    0x1111111111111111ull, 0x22222222222222ull, 0x00ull);
-  quicr::Namespace ns(mask, 120);
-
-  quicr::Name valid_name(formatter_128bit.Encode(
-    0x1111111111111111ull, 0x22222222222222ull, 0xFFull));
-  CHECK(ns.contains(valid_name));
-
-  quicr::Name another_valid_name(formatter_128bit.Encode(
-    0x1111111111111111ull, 0x22222222222222ull, 0x11ull));
-  CHECK(ns.contains(another_valid_name));
-
-  quicr::Name invalid_name(formatter_128bit.Encode(
-    0x1111111111111111ull, 0x22222222222223ull, 0x00ull));
-  CHECK_FALSE(ns.contains(invalid_name));
-}
-
-TEST_CASE("quicr::Namespace Contains Namespaces Test")
-{
-  quicr::Namespace ns(0x11111111111111112222222222220000_name, 112);
-
-  quicr::Namespace valid_namespace(0x11111111111111112222222222222200_name,
-                                   120);
-  CHECK(ns.contains(valid_namespace));
-
-  quicr::Namespace invalid_namespace(0x11111111111111112222222222000000_name,
-                                     104);
-  CHECK_FALSE(ns.contains(invalid_namespace));
 }

--- a/test/namespace.cpp
+++ b/test/namespace.cpp
@@ -1,0 +1,42 @@
+#include <doctest/doctest.h>
+
+#include <quicr/quicr_namespace.h>
+
+#include <type_traits>
+
+TEST_CASE("quicr::Namespace Constructor Tests")
+{
+  CHECK(std::is_trivial_v<quicr::Namespace>);
+  CHECK(std::is_trivially_constructible_v<quicr::Namespace>);
+  CHECK(std::is_trivially_default_constructible_v<quicr::Namespace>);
+  CHECK(std::is_trivially_destructible_v<quicr::Namespace>);
+  CHECK(std::is_trivially_copyable_v<quicr::Namespace>);
+  CHECK(std::is_trivially_copy_assignable_v<quicr::Namespace>);
+  CHECK(std::is_trivially_move_constructible_v<quicr::Namespace>);
+  CHECK(std::is_trivially_move_assignable_v<quicr::Namespace>);
+}
+
+TEST_CASE("quicr::Namespace Contains Names Test")
+{
+  quicr::Namespace base_namespace(0x11111111111111112222222222222200_name, 120);
+
+  quicr::Name valid_name = 0x111111111111111122222222222222FF_name;
+  CHECK(base_namespace.contains(valid_name));
+
+  quicr::Name another_valid_name = 0x11111111111111112222222222222211_name;
+  CHECK(base_namespace.contains(another_valid_name));
+
+  quicr::Name invalid_name = 0x11111111111111112222222222222300_name;
+  CHECK_FALSE(base_namespace.contains(invalid_name));
+}
+
+TEST_CASE("quicr::Namespace Contains Namespaces Test")
+{
+  quicr::Namespace base_namespace(0x11111111111111112222222222220000_name, 112);
+
+  quicr::Namespace valid_namespace(0x11111111111111112222222222222200_name, 120);
+  CHECK(base_namespace.contains(valid_namespace));
+
+  quicr::Namespace invalid_namespace(0x11111111111111112222222222000000_name, 104);
+  CHECK_FALSE(base_namespace.contains(invalid_namespace));
+}

--- a/test/quicr_client.cpp
+++ b/test/quicr_client.cpp
@@ -2,9 +2,9 @@
 #include <string>
 #include <vector>
 
-#include <quicr/encode.h>
 #include "fake_transport.h"
 #include <doctest/doctest.h>
+#include <quicr/encode.h>
 #include <quicr/quicr_client.h>
 
 using namespace quicr;
@@ -63,7 +63,7 @@ TEST_CASE("Subscribe encode, send and receive")
   auto qclient = std::make_unique<QuicRClient>(transport);
 
   qclient->subscribe(sub_delegate,
-                     { { "0x10000000000000002000" }, 125 },
+                     { 0x10000000000000002000_name, 125 },
                      SubscribeIntent::wait_up,
                      "",
                      false,
@@ -76,7 +76,7 @@ TEST_CASE("Subscribe encode, send and receive")
 
   CHECK_EQ(s.transaction_id, s.transaction_id);
   CHECK_EQ(s.quicr_namespace,
-           quicr::Namespace{ { "0x10000000000000002000" }, 125 });
+           quicr::Namespace{ 0x10000000000000002000_name, 125 });
   CHECK_EQ(s.intent, SubscribeIntent::wait_up);
 }
 
@@ -91,7 +91,7 @@ TEST_CASE("Publish encode, send and receive")
   auto qclient = std::make_unique<QuicRClient>(transport);
   std::vector<uint8_t> say_hello = { 'H', 'E', 'L', 'L', '0' };
   qclient->publishNamedObject(
-    { "0x10000000000000002000" }, 0, 0, false, std::move(say_hello));
+    0x10000000000000002000_name, 0, 0, false, std::move(say_hello));
 
   auto fake_transport = std::reinterpret_pointer_cast<FakeTransport>(transport);
   messages::PublishDatagram d;


### PR DESCRIPTION
Weekly attempt to improve benchmark numbers. This PRs numbers:
```
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 2.32, 1.94, 1.57
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_NameConstructFromHexString           29.4 ns         29.4 ns     23692833
BM_NameConstructFromHexStringView       28.5 ns         28.5 ns     24538587
BM_NameConstructFromVector              1.47 ns         1.47 ns    475617794
BM_NameConstructFromBytePointer         1.18 ns         1.18 ns    594479830
BM_NameCopyConstruct                   0.000 ns        0.000 ns   1000000000
BM_NameLeftShift                       0.859 ns        0.859 ns    792796874
BM_NameRightShift                      0.861 ns        0.861 ns    812998688
BM_NameAdd                              1.91 ns         1.91 ns    366935928
BM_NameSub                              1.98 ns         1.98 ns    352746129
BM_NameToHex                            45.8 ns         45.8 ns     14794525
BM_NameRealArithmetic                   19.3 ns         19.3 ns     35832019
BM_MessageBufferConstruct               30.4 ns         30.4 ns     23053009
BM_MessageBufferPushBack                6.84 ns         6.84 ns    100329655
BM_MessageBufferPushBack16              7.07 ns         7.07 ns    100860193
BM_MessageBufferPushBack32              7.49 ns         7.49 ns     97002619
BM_MessageBufferPushBack64              8.45 ns         8.45 ns     89314195
BM_MessageBufferPushBackVector           283 ns          282 ns      3043571
BM_MessageBufferWriteName               36.0 ns         35.9 ns     19847458
BM_HexEndecEncode4x32_to_128            69.1 ns         69.1 ns     10186708
BM_HexEndecDecode128_to_4x32            87.0 ns         87.0 ns      8041263
BM_HexEndecEncode4x16_to_64             14.3 ns         14.3 ns     49008626
BM_HexEndecDecode64_to_4x16             30.9 ns         30.9 ns     22480859
BM_HexEndecRealEncode                   80.5 ns         80.5 ns      8748141
BM_HexEndecRealDecode                    170 ns          170 ns      4158918
```
Vs `main`:
```
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 2.50, 1.73, 1.43
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
BM_NameConstructFromHex               85.8 ns         85.8 ns      8132537
BM_NameConstructFromVector           0.881 ns        0.881 ns    799643587
BM_NameConstructFromBytePointer      0.863 ns        0.863 ns    815546649
BM_NameCopyConstruct                 0.000 ns        0.000 ns   1000000000
BM_NameLeftShift                      2.39 ns         2.39 ns    295603115
BM_NameRightShift                     2.30 ns         2.30 ns    303186490
BM_NameAdd                            1.91 ns         1.91 ns    363053592
BM_NameSub                            1.98 ns         1.98 ns    352671487
BM_NameToHex                           112 ns          112 ns      6318830
BM_NameRealArithmetic                 19.5 ns         19.5 ns     36125117
BM_MessageBufferConstruct             30.3 ns         30.3 ns     23137360
BM_MessageBufferPushBack              6.85 ns         6.85 ns     99383820
BM_MessageBufferPushBack16            7.09 ns         7.09 ns    100850022
BM_MessageBufferPushBack32            7.44 ns         7.44 ns     97759902
BM_MessageBufferPushBack64            8.40 ns         8.40 ns     89611470
BM_MessageBufferPushBackVector         289 ns          285 ns      3036402
BM_MessageBufferWriteName             36.1 ns         36.1 ns     19915955
BM_HexEndecEncode4x32_to_128           146 ns          146 ns      4844693
BM_HexEndecDecode128_to_4x32           156 ns          156 ns      4506883
BM_HexEndecEncode4x16_to_64           50.6 ns         50.6 ns     13956456
BM_HexEndecDecode64_to_4x16           31.8 ns         31.8 ns     21998674
BM_HexEndecRealEncode                  157 ns          157 ns      4466736
BM_HexEndecRealDecode                  288 ns          288 ns      2427344