### PR TITLE
STT Updates: Update transport and remove blocking

### DIFF
--- a/include/quicr/quicr_common.h
+++ b/include/quicr/quicr_common.h
@@ -15,7 +15,7 @@ namespace quicr {
  *    end-to-end, 1400 - 119 = 1281.  A max data size of 1280 should be good
  *    end-to-end for all paths.
  */
-constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1200;
+constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1280;
 
 // TODO: Do we need a different structure or the name
 using bytes = std::vector<uint8_t>;

--- a/include/quicr/quicr_common.h
+++ b/include/quicr/quicr_common.h
@@ -15,7 +15,7 @@ namespace quicr {
  *    end-to-end, 1400 - 119 = 1281.  A max data size of 1280 should be good
  *    end-to-end for all paths.
  */
-constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1280;
+constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1200;
 
 // TODO: Do we need a different structure or the name
 using bytes = std::vector<uint8_t>;

--- a/include/quicr/quicr_common.h
+++ b/include/quicr/quicr_common.h
@@ -15,7 +15,7 @@ namespace quicr {
  *    end-to-end, 1400 - 119 = 1281.  A max data size of 1280 should be good
  *    end-to-end for all paths.
  */
-constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1100;
+constexpr uint16_t MAX_TRANSPORT_DATA_SIZE = 1200;
 
 // TODO: Do we need a different structure or the name
 using bytes = std::vector<uint8_t>;


### PR DESCRIPTION
Update to latest transport and remove enqueue blocking on queue full or error. This applies to all transports. 